### PR TITLE
check if encoding parameter exists

### DIFF
--- a/lib/PicoFeed/Parser/XmlParser.php
+++ b/lib/PicoFeed/Parser/XmlParser.php
@@ -198,8 +198,10 @@ class XmlParser
             $p1 = strpos($data, 'encoding=');
             $p2 = strpos($data, '"', $p1 + 10);
 
-            $encoding = substr($data, $p1 + 10, $p2 - $p1 - 10);
-            $encoding = strtolower($encoding);
+            if ($p1 !== false && $p2 !== false) {
+                $encoding = substr($data, $p1 + 10, $p2 - $p1 - 10);
+                $encoding = strtolower($encoding);
+            }
         }
 
         return $encoding;

--- a/tests/Parser/XmlParserTest.php
+++ b/tests/Parser/XmlParserTest.php
@@ -13,6 +13,7 @@ class XmlParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('utf-8', XmlParser::getEncodingFromXmlTag("<?xml version='1.0' encoding='UTF-8'?><?xml-stylesheet"));
         $this->assertEquals('utf-8', XmlParser::getEncodingFromXmlTag('<?xml version="1.0" encoding="UTF-8"?><feed xml:'));
         $this->assertEquals('windows-1251', XmlParser::getEncodingFromXmlTag('<?xml version="1.0" encoding="Windows-1251"?><rss version="2.0">'));
+        $this->assertEquals('', XmlParser::getEncodingFromXmlTag("<?xml version='1.0'?><?xml-stylesheet"));
     }
 
     public function testScanForXEE()


### PR DESCRIPTION
getEncodingFromXmlTag returns unexpected garbage otherwise. This bug is hidden by Encoding:convert() since the function converts everything to utf-8 that is unknown by preserving existing utf-8 characters.

This issue is exposed with https://en.wikipedia.org/w/api.php?action=featuredfeed&feed=featured&feedformat=atom