### PR TITLE
set the final url for fopen as well #2

### DIFF
--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -262,48 +262,6 @@ abstract class Client
         }
     }
 
-     /**
-     * Handle manually redirections when there is an open base dir restriction
-     *
-     * @access private
-     * @param  string     $location       Redirected URL
-     * @return array
-     */
-    public function handleRedirection($location)
-    {
-        $nb_redirects = 0;
-        $result = array();
-        $this->url = Url::resolve($location, $this->url);
-        $this->body = '';
-        $this->body_length = 0;
-        $this->headers = array();
-        $this->headers_counter = 0;
-
-        while (true) {
-
-            $nb_redirects++;
-
-            if ($nb_redirects >= $this->max_redirects) {
-                throw new MaxRedirectException('Maximum number of redirections reached');
-            }
-
-            $result = $this->doRequest(false);
-
-            if ($result['status'] == 301 || $result['status'] == 302) {
-                $this->url = $result['headers']['Location'];
-                $this->body = '';
-                $this->body_length = 0;
-                $this->headers = array();
-                $this->headers_counter = 0;
-            }
-            else {
-                break;
-            }
-        }
-
-        return $result;
-    }
-
     /**
      * Check if a request has been modified according to the parameters
      *

--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -158,46 +158,13 @@ abstract class Client
     protected $status_code = 0;
 
     /**
-     * HTTP response body
-     *
-     * @access protected
-     * @var string
-     */
-    protected $body = '';
-
-    /**
-     * Body size
-     *
-     * @access protected
-     * @var integer
-     */
-    protected $body_length = 0;
-
-    /**
-     * HTTP response headers
-     *
-     * @access protected
-     * @var array
-     */
-    protected $headers = array();
-
-    /**
-     * Counter on the number of header received
-     *
-     * @access protected
-     * @var integer
-     */
-    protected $headers_counter = 0;
-
-    /**
      * Do the HTTP request
      *
      * @abstract
      * @access public
-     * @param  bool      $follow_location    Flag used when there is an open_basedir restriction
      * @return array
      */
-    abstract public function doRequest($follow_location = true);
+    abstract public function doRequest();
 
     /**
      * Get client instance: curl or stream driver

--- a/lib/PicoFeed/Client/Curl.php
+++ b/lib/PicoFeed/Client/Curl.php
@@ -261,6 +261,48 @@ class Curl extends Client
     }
 
     /**
+     * Handle manually redirections when there is an open base dir restriction
+     *
+     * @access private
+     * @param  string     $location       Redirected URL
+     * @return array
+     */
+    private function handleRedirection($location)
+    {
+        $nb_redirects = 0;
+        $result = array();
+        $this->url = $location;
+        $this->body = '';
+        $this->body_length = 0;
+        $this->headers = array();
+        $this->headers_counter = 0;
+
+        while (true) {
+
+            $nb_redirects++;
+
+            if ($nb_redirects >= $this->max_redirects) {
+                throw new MaxRedirectException('Maximum number of redirections reached');
+            }
+
+            $result = $this->doRequest(false);
+
+            if ($result['status'] == 301 || $result['status'] == 302) {
+                $this->url = $result['headers']['Location'];
+                $this->body = '';
+                $this->body_length = 0;
+                $this->headers = array();
+                $this->headers_counter = 0;
+            }
+            else {
+                break;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Handle cURL errors (throw individual exceptions)
      *
      * We don't use constants because they are not necessary always available

--- a/lib/PicoFeed/Client/Curl.php
+++ b/lib/PicoFeed/Client/Curl.php
@@ -271,7 +271,7 @@ class Curl extends Client
     {
         $nb_redirects = 0;
         $result = array();
-        $this->url = $location;
+        $this->url = Url::resolve($location, $this->url);
         $this->body = '';
         $this->body_length = 0;
         $this->headers = array();
@@ -288,7 +288,7 @@ class Curl extends Client
             $result = $this->doRequest(false);
 
             if ($result['status'] == 301 || $result['status'] == 302) {
-                $this->url = $result['headers']['Location'];
+                $this->url = Url::resolve($result['headers']['Location'], $this->url);
                 $this->body = '';
                 $this->body_length = 0;
                 $this->headers = array();

--- a/lib/PicoFeed/Client/Curl.php
+++ b/lib/PicoFeed/Client/Curl.php
@@ -13,6 +13,38 @@ use PicoFeed\Logging\Logger;
 class Curl extends Client
 {
     /**
+     * HTTP response body
+     *
+     * @access private
+     * @var string
+     */
+    private $body = '';
+
+    /**
+     * Body size
+     *
+     * @access private
+     * @var integer
+     */
+    private $body_length = 0;
+
+    /**
+     * HTTP response headers
+     *
+     * @access private
+     * @var array
+     */
+    private $headers = array();
+
+    /**
+     * Counter on the number of header received
+     *
+     * @access private
+     * @var integer
+     */
+    private $headers_counter = 0;
+
+    /**
      * cURL callback to read the HTTP body
      *
      * If the function return -1, curl stop to read the HTTP response

--- a/lib/PicoFeed/Client/HttpHeaders.php
+++ b/lib/PicoFeed/Client/HttpHeaders.php
@@ -53,12 +53,13 @@ class HttpHeaders implements ArrayAccess
      */
     public static function parse(array $lines)
     {
-        $status = 200;
+        $status = 0;
         $headers = array();
 
         foreach ($lines as $line) {
 
             if (strpos($line, 'HTTP') === 0) {
+                $headers = array();
                 $status = (int) substr($line, 9, 3);
             }
             else if (strpos($line, ':') !== false) {

--- a/lib/PicoFeed/Client/Stream.php
+++ b/lib/PicoFeed/Client/Stream.php
@@ -61,7 +61,7 @@ class Stream extends Client
                 'method' => 'GET',
                 'protocol_version' => 1.1,
                 'timeout' => $this->timeout,
-                'follow_location' => 0,
+                'max_redirects' => $this->max_redirects,
             )
         );
 
@@ -91,7 +91,7 @@ class Stream extends Client
      * @access public
      * @return array   HTTP response ['body' => ..., 'status' => ..., 'headers' => ...]
      */
-    public function doRequest($follow_location = false)
+    public function doRequest()
     {
         // Create context
         $context = stream_context_create($this->prepareContext());
@@ -120,12 +120,6 @@ class Stream extends Client
         list($status, $headers) = HttpHeaders::parse($metadata['wrapper_data']);
 
         fclose($stream);
-
-        // Do redirect manual to get only the headers of the last request and
-        // the final url
-        if ($status == 301 || $status == 302) {
-            return $this->handleRedirection($headers['Location']);
-        }
 
         return array(
             'status' => $status,

--- a/lib/PicoFeed/Client/Stream.php
+++ b/lib/PicoFeed/Client/Stream.php
@@ -89,8 +89,7 @@ class Stream extends Client
      * Do the HTTP request
      *
      * @access public
-     * @param  bool    $follow_location    Flag used when there is an open_basedir restriction
-     * @return array                       HTTP response ['body' => ..., 'status' => ..., 'headers' => ...]
+     * @return array   HTTP response ['body' => ..., 'status' => ..., 'headers' => ...]
      */
     public function doRequest($follow_location = false)
     {

--- a/tests/Client/CurlTest.php
+++ b/tests/Client/CurlTest.php
@@ -18,17 +18,17 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('text/html; charset=utf-8', $result['headers']['Content-Type']);
     }
 
-
     public function testRedirect()
     {
         $client = new Curl;
-        $client->setUrl('http://www.miniflux.net/index.html');
+        $client->setUrl('http://rss.feedsportal.com/c/629/f/502199/s/42e50391/sc/44/l/0L0S0A1net0N0Ceditorial0C6437220Candroid0Egoogle0Enow0Es0Eouvre0Eaux0Eapplications0Etierces0C0T0Dxtor0FRSS0E16/story01.htm');
         $result = $client->doRequest();
 
         $this->assertTrue(is_array($result));
         $this->assertEquals(200, $result['status']);
         $this->assertEquals('<!DOCTYPE', substr($result['body'], 0, 9));
-        $this->assertEquals('text/html; charset=utf-8', $result['headers']['Content-Type']);
+        $this->assertEquals('text/html', $result['headers']['Content-Type']);
+        $this->assertEquals('http://www.01net.com/editorial/643722/android-google-now-s-ouvre-aux-applications-tierces/', str_replace('#?xtor=RSS-16', '', $client->getUrl()));
     }
 
     /**

--- a/tests/Client/CurlTest.php
+++ b/tests/Client/CurlTest.php
@@ -29,7 +29,6 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(200, $result['status']);
         $this->assertEquals('<!DOCTYPE', substr($result['body'], 0, 9));
         $this->assertEquals('text/html; charset=utf-8', $result['headers']['Content-Type']);
-        $this->assertEquals('http://miniflux.net/', $client->getUrl());
     }
 
     /**

--- a/tests/Client/StreamTest.php
+++ b/tests/Client/StreamTest.php
@@ -30,14 +30,12 @@ class StreamTest extends PHPUnit_Framework_TestCase
     public function testRedirect()
     {
         $client = new Stream;
-        $client->setUrl('http://www.miniflux.net/index.html');
+        $client->setUrl('http://github.com/fguillot/picoFeed');
         $result = $client->doRequest();
 
-        $this->assertTrue(is_array($result));
         $this->assertEquals(200, $result['status']);
-        $this->assertEquals('<!DOCTYPE', substr($result['body'], 0, 9));
+        $this->assertEquals('<!DOCTYPE html>', substr(trim($result['body']), 0, 15));
         $this->assertEquals('text/html; charset=utf-8', $result['headers']['Content-Type']);
-        $this->assertEquals('http://miniflux.net/', $client->getUrl());
     }
 
     /**

--- a/tests/Client/StreamTest.php
+++ b/tests/Client/StreamTest.php
@@ -30,12 +30,14 @@ class StreamTest extends PHPUnit_Framework_TestCase
     public function testRedirect()
     {
         $client = new Stream;
-        $client->setUrl('http://github.com/fguillot/picoFeed');
+        $client->setUrl('http://rss.feedsportal.com/c/629/f/502199/s/42e50391/sc/44/l/0L0S0A1net0N0Ceditorial0C6437220Candroid0Egoogle0Enow0Es0Eouvre0Eaux0Eapplications0Etierces0C0T0Dxtor0FRSS0E16/story01.htm');
         $result = $client->doRequest();
 
+        $this->assertTrue(is_array($result));
         $this->assertEquals(200, $result['status']);
-        $this->assertEquals('<!DOCTYPE html>', substr(trim($result['body']), 0, 15));
-        $this->assertEquals('text/html; charset=utf-8', $result['headers']['Content-Type']);
+        $this->assertEquals('<!DOCTYPE', substr($result['body'], 0, 9));
+        $this->assertEquals('text/html', $result['headers']['Content-Type']);
+        $this->assertEquals('http://www.01net.com/editorial/643722/android-google-now-s-ouvre-aux-applications-tierces/#?xtor=RSS-16', $client->getUrl());
     }
 
     /**

--- a/tests/Parser/DateParserTest.php
+++ b/tests/Parser/DateParserTest.php
@@ -32,17 +32,17 @@ class DateParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('2010-08-20', date('Y-m-d', $parser->getTimestamp('2010-08-20Thh:08:ssZ')));
         $this->assertEquals(1288648057, $parser->getTimestamp('Mon, 01 Nov 2010 21:47:37 UT'));
         $this->assertEquals(1346069615, $parser->getTimestamp('Mon Aug 27 2012 12:13:35 GMT-0700 (PDT)'));
-        $this->assertEquals(time(), $parser->getTimestamp('Tue, 3 Febuary 2010 00:00:00 IST'), 1);
-        $this->assertEquals(time(), $parser->getTimestamp('############# EST'), 1);
-        $this->assertEquals(time(), $parser->getTimestamp('Wed, 30 Nov -0001 00:00:00 +0000'), 1);
-        $this->assertEquals(time(), $parser->getTimestamp('čet, 24 maj 2012 00:00:00'), 1);
-        $this->assertEquals(time(), $parser->getTimestamp('-0-0T::Z'), 1);
-        $this->assertEquals(time(), $parser->getTimestamp('Wed, 18 2012'), 1);
-        $this->assertEquals(time(), $parser->getTimestamp("'2009-09-30 CDT16:09:54"), 1);
-        $this->assertEquals(time(), $parser->getTimestamp('ary 8 Jan 2013 00:00:00 GMT'), 1);
-        $this->assertEquals(time(), $parser->getTimestamp('Sat, 11 00:00:01 GMT'), 1);
+        $this->assertEquals(time(), $parser->getTimestamp('Tue, 3 Febuary 2010 00:00:00 IST'), '', 1);
+        $this->assertEquals(time(), $parser->getTimestamp('############# EST'), '', 1);
+        $this->assertEquals(time(), $parser->getTimestamp('Wed, 30 Nov -0001 00:00:00 +0000'), '', 1);
+        $this->assertEquals(time(), $parser->getTimestamp('čet, 24 maj 2012 00:00:00'), '', 1);
+        $this->assertEquals(time(), $parser->getTimestamp('-0-0T::Z'), '', 1);
+        $this->assertEquals(time(), $parser->getTimestamp('Wed, 18 2012'), '', 1);
+        $this->assertEquals(time(), $parser->getTimestamp("'2009-09-30 CDT16:09:54"), '', 1);
+        $this->assertEquals(time(), $parser->getTimestamp('ary 8 Jan 2013 00:00:00 GMT'), '', 1);
+        $this->assertEquals(time(), $parser->getTimestamp('Sat, 11 00:00:01 GMT'), '', 1);
         $this->assertEquals(1370631743, $parser->getTimestamp('Fri Jun 07 2013 19:02:23 GMT+0000 (UTC)'));
         $this->assertEquals(1377412225, $parser->getTimestamp('25/08/2013 06:30:25 م'));
-        $this->assertEquals(time(), $parser->getTimestamp('+0400'),1);
+        $this->assertEquals(time(), $parser->getTimestamp('+0400'), '', 1);
     }
 }

--- a/tests/Parser/Rss20ParserTest.php
+++ b/tests/Parser/Rss20ParserTest.php
@@ -93,7 +93,7 @@ class Rss20ParserTest extends PHPUnit_Framework_TestCase
 
         $parser = new Rss20(file_get_contents('tests/fixtures/fulltextrss.xml'));
         $feed = $parser->execute();
-        $this->assertEquals(time(), $feed->getDate(), 1);
+        $this->assertEquals(time(), $feed->getDate(), '', 1);
     }
 
     public function testFeedLanguage()

--- a/tests/Parser/Rss91ParserTest.php
+++ b/tests/Parser/Rss91ParserTest.php
@@ -18,13 +18,13 @@ class Rss91ParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $feed->getFeedUrl());
         $this->assertEquals('http://writetheweb.com/', $feed->getSiteUrl());
         $this->assertEquals('http://writetheweb.com/', $feed->getId());
-        $this->assertEquals(time(), $feed->getDate(), 1);
+        $this->assertEquals(time(), $feed->getDate(), '', 1);
         $this->assertEquals(6, count($feed->items));
 
         $this->assertEquals('Giving the world a pluggable Gnutella', $feed->items[0]->getTitle());
         $this->assertEquals('http://writetheweb.com/read.php?item=24', $feed->items[0]->getUrl());
         $this->assertEquals('085a9133a75542f878fa73ee2afbb6a2350b6c4fb125e6d8ca09478c47702111', $feed->items[0]->getId());
-        $this->assertEquals(time(), $feed->items[0]->getDate(), 1);
+        $this->assertEquals(time(), $feed->items[0]->getDate(), '', 1);
         $this->assertEquals('webmaster@writetheweb.com', $feed->items[0]->getAuthor());
         $this->assertTrue(strpos($feed->items[1]->getContent(), '<p>After a period of dormancy') === 0);
     }

--- a/tests/Parser/Rss92ParserTest.php
+++ b/tests/Parser/Rss92ParserTest.php
@@ -18,7 +18,7 @@ class Rss92ParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $feed->getFeedUrl());
         $this->assertEquals('http://www.universfreebox.com/', $feed->getSiteUrl());
         $this->assertEquals('http://www.universfreebox.com/', $feed->getId());
-        $this->assertEquals(time(), $feed->date, 1);
+        $this->assertEquals(time(), $feed->date, '', 1);
         $this->assertEquals(30, count($feed->items));
 
         $this->assertEquals('Retour de Xavier Niel sur Twitter, « sans initiative privée, pas de révolution #Born2code »', $feed->items[0]->title);


### PR DESCRIPTION
I had to revert the former fix, as it does not work as intended with php versions < 5.3.4 and miniflux targets php 5.3.3. Problem was the fopen context parameter "follow_location", which is not available for older php versions. I've implemented another approach to fix the bug.

Fixed an additional bug for curl + open_basedir which appeared only if more than one redirection occurs.

@Raydiation

HttpHeaders::parse() returns now 0 as default status code if no status response header could be found. Returning "success" as default value looks kind of bogus to me. Correct me if I missed something! I stumbled upon on this, while I was checking single response headers if they are a status code or a content-type header.