### PR TITLE
add passthrough download mode,  add option to limit image proxying to a specific protocol

### DIFF
--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -158,6 +158,14 @@ abstract class Client
     protected $status_code = 0;
 
     /**
+     * Enables direct passthrough to requesting client
+     *
+     * @access protected
+     * @var bool
+     */
+    protected $passthrough = false;
+
+    /**
      * Do the HTTP request
      *
      * @abstract
@@ -463,6 +471,17 @@ abstract class Client
     }
 
     /**
+     * return true if passthrough mode is enabled
+     *
+     * @access public
+     * @return bool
+     */
+    public function isPassthroughEnabled()
+    {
+        return $this->passthrough;
+    }
+
+    /**
      * Set connection timeout
      *
      * @access public
@@ -589,6 +608,30 @@ abstract class Client
     public function setPassword($password)
     {
         $this->password = $password ?: $this->password;
+        return $this;
+    }
+
+    /**
+     * enable the passthrough mode
+     *
+     * @access public
+     * @return \PicoFeed\Client\Client
+     */
+    public function enablePassthroughMode()
+    {
+        $this->passthrough = true;
+        return $this;
+    }
+
+    /**
+     * disable the passthrough mode
+     *
+     * @access public
+     * @return \PicoFeed\Client\Client
+     */
+    public function disablePassthroughMode()
+    {
+        $this->passthrough = false;
         return $this;
     }
 

--- a/lib/PicoFeed/Config/Config.php
+++ b/lib/PicoFeed/Config/Config.php
@@ -32,6 +32,7 @@ namespace PicoFeed\Config;
  * @method  \PicoFeed\Config\Config setFilterBlacklistedTags(array $value)
  * @method  \PicoFeed\Config\Config setFilterImageProxyUrl($value)
  * @method  \PicoFeed\Config\Config setFilterImageProxyCallback($closure)
+ * @method  \PicoFeed\Config\Config setFilterImageProxyLimitToProto($value)
  *
  * @method  integer    getClientTimeout()
  * @method  string     getClientUserAgent()
@@ -57,6 +58,7 @@ namespace PicoFeed\Config;
  * @method  array      getFilterBlacklistedTags(array $default_value)
  * @method  string     getFilterImageProxyUrl()
  * @method  \Closure   getFilterImageProxyCallback()
+ * @method  string     getFilterImageProxyLimitToProto()
  */
 class Config
 {

--- a/lib/PicoFeed/Filter/Attribute.php
+++ b/lib/PicoFeed/Filter/Attribute.php
@@ -29,6 +29,14 @@ class Attribute
     private $image_proxy_callback = null;
 
     /**
+     * limits the image proxy usage to this protocol
+     *
+     * @access private
+     * @var string
+     */
+    private $image_proxy_limit_protocol = '';
+
+    /**
      * Tags and attribute whitelist
      *
      * @access private
@@ -273,8 +281,8 @@ class Attribute
      *
      * @access public
      * @param  string    $tag           Tag name
-     * @param  string    $attribute     Atttribute name
-     * @param  string    $value         Atttribute value
+     * @param  string    $attribute     Attribute name
+     * @param  string    $value         Attribute value
      * @return boolean
      */
     public function filterEmptyAttribute($tag, $attribute, $value)
@@ -287,8 +295,8 @@ class Attribute
      *
      * @access public
      * @param  string    $tag           Tag name
-     * @param  string    $attribute     Atttribute name
-     * @param  string    $value         Atttribute value
+     * @param  string    $attribute     Attribute name
+     * @param  string    $value         Attribute value
      * @return boolean
      */
     public function filterAllowedAttribute($tag, $attribute, $value)
@@ -301,8 +309,8 @@ class Attribute
      *
      * @access public
      * @param  string    $tag           Tag name
-     * @param  string    $attribute     Atttribute name
-     * @param  string    $value         Atttribute value
+     * @param  string    $attribute     Attribute name
+     * @param  string    $value         Attribute value
      * @return boolean
      */
     public function filterIntegerAttribute($tag, $attribute, $value)
@@ -319,8 +327,8 @@ class Attribute
      *
      * @access public
      * @param  string    $tag           Tag name
-     * @param  string    $attribute     Atttribute name
-     * @param  string    $value         Atttribute value
+     * @param  string    $attribute     Attribute name
+     * @param  string    $value         Attribute value
      * @return boolean
      */
     public function filterIframeAttribute($tag, $attribute, $value)
@@ -344,8 +352,8 @@ class Attribute
      *
      * @access public
      * @param  string    $tag           Tag name
-     * @param  string    $attribute     Atttribute name
-     * @param  string    $value         Atttribute value
+     * @param  string    $attribute     Attribute name
+     * @param  string    $value         Attribute value
      * @return boolean
      */
     public function filterBlacklistResourceAttribute($tag, $attribute, $value)
@@ -362,8 +370,8 @@ class Attribute
      *
      * @access public
      * @param  string    $tag           Tag name
-     * @param  string    $attribute     Atttribute name
-     * @param  string    $value         Atttribute value
+     * @param  string    $attribute     Attribute name
+     * @param  string    $value         Attribute value
      * @return boolean
      */
     public function rewriteAbsoluteUrl($tag, $attribute, &$value)
@@ -376,17 +384,18 @@ class Attribute
     }
 
     /**
-     * Rewrite image url to use with a proxy (HTTPS resource are ignored)
+     * Rewrite image url to use with a proxy
      *
      * @access public
      * @param  string    $tag           Tag name
-     * @param  string    $attribute     Atttribute name
-     * @param  string    $value         Atttribute value
+     * @param  string    $attribute     Attribute name
+     * @param  string    $value         Attribute value
      * @return boolean
      */
     public function rewriteImageProxyUrl($tag, $attribute, &$value)
     {
-        if ($tag === 'img' && $attribute === 'src' && strpos($value, 'http:') === 0) {
+        if ($tag === 'img' && $attribute === 'src'
+	    && ! ($this->image_proxy_limit_protocol !== '' && stripos($value, $this->image_proxy_limit_protocol.':') !== 0)) {
 
             if ($this->image_proxy_url) {
                 $value = sprintf($this->image_proxy_url, rawurlencode($value));
@@ -404,8 +413,8 @@ class Attribute
      *
      * @access public
      * @param  string    $tag           Tag name
-     * @param  string    $attribute     Atttribute name
-     * @param  string    $value         Atttribute value
+     * @param  string    $attribute     Attribute name
+     * @param  string    $value         Attribute value
      * @return boolean
      */
     public function filterProtocolUrlAttribute($tag, $attribute, $value)
@@ -422,7 +431,7 @@ class Attribute
      *
      * @access public
      * @param  string    $tag            Tag name
-     * @param  array     $attributes     Atttributes list
+     * @param  array     $attributes     Attributes list
      * @return array
      */
     public function addAttributes($tag, array $attributes)
@@ -439,7 +448,7 @@ class Attribute
      *
      * @access public
      * @param  string    $tag            Tag name
-     * @param  array     $attributes     Atttributes list
+     * @param  array     $attributes     Attributes list
      * @return boolean
      */
     public function hasRequiredAttributes($tag, array $attributes)
@@ -653,6 +662,12 @@ class Attribute
     public function setImageProxyCallback($callback)
     {
         $this->image_proxy_callback = $callback ?: $this->image_proxy_callback;
+        return $this;
+    }
+
+    public function setImageProxyLimitToProto($value)
+    {
+        $this->image_proxy_limit_protocol = $value ?: $this->image_proxy_limit_protocol;
         return $this;
     }
 }

--- a/lib/PicoFeed/Filter/Html.php
+++ b/lib/PicoFeed/Filter/Html.php
@@ -98,6 +98,7 @@ class Html
         if ($this->config !== null) {
             $this->attribute->setImageProxyCallback($this->config->getFilterImageProxyCallback());
             $this->attribute->setImageProxyUrl($this->config->getFilterImageProxyUrl());
+            $this->attribute->setImageProxyLimitToProto($this->config->getFilterImageProxyLimitToProto());
             $this->attribute->setIframeWhitelist($this->config->getFilterIframeWhitelist(array()));
             $this->attribute->setIntegerAttributes($this->config->getFilterIntegerAttributes(array()));
             $this->attribute->setAttributeOverrides($this->config->getFilterAttributeOverrides(array()));

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -18,6 +18,20 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($client->getLastModified());
     }
 
+//    // disabled due to https://github.com/sebastianbergmann/phpunit/issues/1452
+//    /**
+//     * @runInSeparateProcess
+//     */
+//    public function testPassthrough()
+//    {
+//        $client = Client::getInstance();
+//        $client->setUrl('http://miniflux.net/favicon.ico');
+//        $client->enablePassthroughMode();
+//        $client->execute();
+//
+//        $this->expectOutputString('no_to_be_defined');
+//    }
+
     public function testCacheBothHaveToMatch()
     {
         $client = Client::getInstance();

--- a/tests/Client/CurlTest.php
+++ b/tests/Client/CurlTest.php
@@ -18,6 +18,20 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('text/html; charset=utf-8', $result['headers']['Content-Type']);
     }
 
+//    // disabled due to https://github.com/sebastianbergmann/phpunit/issues/1452
+//    /**
+//     * @runInSeparateProcess
+//     */
+//    public function testPassthrough()
+//    {
+//        $client = new Curl;
+//        $client->setUrl('http://miniflux.net/favicon.ico');
+//        $client->enablePassthroughMode();
+//        $client->doRequest();
+//
+//        $this->expectOutputString('no_to_be_defined');
+//    }
+
     public function testRedirect()
     {
         $client = new Curl;

--- a/tests/Client/StreamTest.php
+++ b/tests/Client/StreamTest.php
@@ -27,6 +27,20 @@ class StreamTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('</html>', substr(trim($result['body']), -7));
     }
 
+//    // disabled due to https://github.com/sebastianbergmann/phpunit/issues/1452
+//    /**
+//     * @runInSeparateProcess
+//     */
+//    public function testPassthrough()
+//    {
+//        $client = new Stream;
+//        $client->setUrl('http://miniflux.net/favicon.ico');
+//        $client->enablePassthroughMode();
+//        $client->doRequest();
+//
+//        $this->expectOutputString('no_to_be_defined');
+//    }
+
     public function testRedirect()
     {
         $client = new Stream;

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -90,7 +90,7 @@ class FilterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<p>Testboo</p>', $f->execute());
     }
 
-    public function testImageProxy()
+    public function testNoImageProxySet()
     {
         $f = Filter::html('<p>Image <img src="/image.png" alt="My Image"/></p>', 'http://foo');
 
@@ -98,10 +98,71 @@ class FilterTest extends PHPUnit_Framework_TestCase
             '<p>Image <img src="http://foo/image.png" alt="My Image"/></p>',
             $f->execute()
         );
+    }
 
-        // Test setFilterImageProxyUrl and HTTPS
+    public function testImageProxyWithHTTPLink()
+    {
         $config = new Config;
         $config->setFilterImageProxyUrl('http://myproxy/?url=%s');
+
+        $f = Filter::html('<p>Image <img src="http://localhost/image.png" alt="My Image"/></p>', 'http://foo');
+        $f->setConfig($config);
+
+        $this->assertEquals(
+            '<p>Image <img src="http://myproxy/?url='.rawurlencode('http://localhost/image.png').'" alt="My Image"/></p>',
+            $f->execute()
+        );
+    }
+
+    public function testImageProxyWithHTTPSLink()
+    {
+        $config = new Config;
+        $config->setFilterImageProxyUrl('http://myproxy/?url=%s');
+
+        $f = Filter::html('<p>Image <img src="https://localhost/image.png" alt="My Image"/></p>', 'http://foo');
+        $f->setConfig($config);
+
+        $this->assertEquals(
+            '<p>Image <img src="http://myproxy/?url='.rawurlencode('https://localhost/image.png').'" alt="My Image"/></p>',
+            $f->execute()
+        );
+    }
+
+    public function testImageProxyLimitedToUnknownProtocol()
+    {
+        $config = new Config;
+        $config->setFilterImageProxyUrl('http://myproxy/?url=%s');
+        $config->setFilterImageProxyLimitToProto('tripleX');
+
+        $f = Filter::html('<p>Image <img src="http://localhost/image.png" alt="My Image"/></p>', 'http://foo');
+        $f->setConfig($config);
+
+        $this->assertEquals(
+            '<p>Image <img src="http://localhost/image.png" alt="My Image"/></p>',
+            $f->execute()
+        );
+    }
+
+    public function testImageProxyLimitedToHTTPwithHTTPLink()
+    {
+        $config = new Config;
+        $config->setFilterImageProxyUrl('http://myproxy/?url=%s');
+        $config->setFilterImageProxyLimitToProto('http');
+
+        $f = Filter::html('<p>Image <img src="http://localhost/image.png" alt="My Image"/></p>', 'http://foo');
+        $f->setConfig($config);
+
+        $this->assertEquals(
+            '<p>Image <img src="http://myproxy/?url='.rawurlencode('http://localhost/image.png').'" alt="My Image"/></p>',
+            $f->execute()
+        );
+    }
+
+    public function testImageProxyLimitedToHTTPwithHTTPSLink()
+    {
+        $config = new Config;
+        $config->setFilterImageProxyUrl('http://myproxy/?url=%s');
+        $config->setFilterImageProxyLimitToProto('http');
 
         $f = Filter::html('<p>Image <img src="https://localhost/image.png" alt="My Image"/></p>', 'http://foo');
         $f->setConfig($config);
@@ -110,20 +171,40 @@ class FilterTest extends PHPUnit_Framework_TestCase
             '<p>Image <img src="https://localhost/image.png" alt="My Image"/></p>',
             $f->execute()
         );
+    }
 
-        // Test setFilterImageProxyUrl
+    public function testImageProxyLimitedToHTTPSwithHTTPLink()
+    {
         $config = new Config;
         $config->setFilterImageProxyUrl('http://myproxy/?url=%s');
+        $config->setFilterImageProxyLimitToProto('https');
 
-        $f = Filter::html('<p>Image <img src="/image.png" alt="My Image"/></p>', 'http://foo');
+        $f = Filter::html('<p>Image <img src="http://localhost/image.png" alt="My Image"/></p>', 'http://foo');
         $f->setConfig($config);
 
         $this->assertEquals(
-            '<p>Image <img src="http://myproxy/?url='.rawurlencode('http://foo/image.png').'" alt="My Image"/></p>',
+            '<p>Image <img src="http://localhost/image.png" alt="My Image"/></p>',
             $f->execute()
         );
+    }
 
-        // Test setFilterImageProxyCallback
+    public function testImageProxyLimitedToHTTPSwithHTTPSLink()
+    {
+        $config = new Config;
+        $config->setFilterImageProxyUrl('http://myproxy/?url=%s');
+        $config->setFilterImageProxyLimitToProto('https');
+
+        $f = Filter::html('<p>Image <img src="https://localhost/image.png" alt="My Image"/></p>', 'http://foo');
+        $f->setConfig($config);
+
+        $this->assertEquals(
+            '<p>Image <img src="http://myproxy/?url='.rawurlencode('https://localhost/image.png').'" alt="My Image"/></p>',
+            $f->execute()
+        );
+    }
+
+    public function testsetFilterImageProxyCallback()
+    {
         $config = new Config;
         $config->setFilterImageProxyCallback(function ($image_url) {
             $key = hash_hmac('sha1', $image_url, 'secret');


### PR DESCRIPTION
__add passthrough download mode__

It's meant to be used by image proxies that are backed by picoFeed functions
like the image proxy in miniflux.

__add option to limit image proxying to a specific protocol__

reverts d3785fc and implements an option to
set the targeted protocol.

One use case where the image proxy should be used with HTTPS urls is referrer
cloaking.