### PR TITLE
Turn whitelisted http iframes into https iframes

### DIFF
--- a/lib/PicoFeed/Filter/Attribute.php
+++ b/lib/PicoFeed/Filter/Attribute.php
@@ -139,18 +139,6 @@ class Attribute
     );
 
     /**
-     * Iframe source whitelist which will be converted from http to https
-     *
-     * @access private
-     * @var array
-     */
-    private $secure_iframe_whitelist = array(
-        'http://www.youtube.com',
-        'http://player.vimeo.com',
-        'http://www.dailymotion.com',
-    );
-
-    /**
      * Blacklisted resources
      *
      * @access private
@@ -245,6 +233,7 @@ class Attribute
         'filterBlacklistResourceAttribute',
         'filterProtocolUrlAttribute',
         'rewriteImageProxyUrl',
+        'secureIframeSrc',
     );
 
     /**
@@ -396,6 +385,24 @@ class Attribute
     }
 
     /**
+     * Turns iframes' src attribute from http to https to prevent
+     * mixed active content
+     *
+     * @access public
+     * @param  string    $tag            Tag name
+     * @param  array     $attributes     Atttributes list
+     * @return array
+     */
+    public function secureIframeSrc($tag, $attribute, &$value)
+    {
+        if ($tag === 'iframe' && $attribute === 'src' && strpos($value, 'http://') === 0) {
+            $value = substr_replace($value, 's', 4, 0);
+        }
+
+        return true;
+    }
+
+    /**
      * Rewrite image url to use with a proxy
      *
      * @access public
@@ -450,31 +457,6 @@ class Attribute
     {
         if (isset($this->add_attributes[$tag])) {
             $attributes += $this->add_attributes[$tag];
-        }
-
-        $attributes = $this->secureIframe($tag, $attributes);
-
-        return $attributes;
-    }
-
-    /**
-     * Turns whitelisted iframes' src attribute from http to https to prevent
-     * mixed active content
-     *
-     * @access public
-     * @param  string    $tag            Tag name
-     * @param  array     $attributes     Atttributes list
-     * @return array
-     */
-    private function secureIframe($tag, array $attributes)
-    {
-        if ($tag === 'iframe') {
-            $src = $attributes['src'];
-            foreach ($this->secure_iframe_whitelist as $url) {
-                if (strpos($src, $url) === 0) {
-                    $attributes['src'] = substr_replace($src, 's', 4, 0);
-                }
-            }
         }
 
         return $attributes;

--- a/lib/PicoFeed/Filter/Attribute.php
+++ b/lib/PicoFeed/Filter/Attribute.php
@@ -139,6 +139,18 @@ class Attribute
     );
 
     /**
+     * Iframe source whitelist which will be converted from http to https
+     *
+     * @access private
+     * @var array
+     */
+    private $secure_iframe_whitelist = array(
+        'http://www.youtube.com',
+        'http://player.vimeo.com',
+        'http://www.dailymotion.com',
+    );
+
+    /**
      * Blacklisted resources
      *
      * @access private
@@ -438,6 +450,31 @@ class Attribute
     {
         if (isset($this->add_attributes[$tag])) {
             $attributes += $this->add_attributes[$tag];
+        }
+
+        $attributes = $this->secureIframe($tag, $attributes);
+
+        return $attributes;
+    }
+
+    /**
+     * Turns whitelisted iframes' src attribute from http to https to prevent
+     * mixed active content
+     *
+     * @access public
+     * @param  string    $tag            Tag name
+     * @param  array     $attributes     Atttributes list
+     * @return array
+     */
+    private function secureIframe($tag, array $attributes)
+    {
+        if ($tag === 'iframe') {
+            $src = $attributes['src'];
+            foreach ($this->secure_iframe_whitelist as $url) {
+                if (strpos($src, $url) === 0) {
+                    $attributes['src'] = substr_replace($src, 's', 4, 0);
+                }
+            }
         }
 
         return $attributes;

--- a/tests/Filter/AttributeFilterTest.php
+++ b/tests/Filter/AttributeFilterTest.php
@@ -39,8 +39,8 @@ class AttributeFilterTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($filter->filterIntegerAttribute('iframe', 'width', '450'));
         $this->assertFalse($filter->filterIntegerAttribute('iframe', 'width', 'test'));
 
-        $this->assertEquals(array('width' => '10', 'src' => 'http://www.youtube.com/test'), $filter->filter('iframe', array('width' => '10', 'src' => 'http://www.youtube.com/test')));
-        $this->assertEquals(array('src' => 'http://www.youtube.com/test'), $filter->filter('iframe', array('width' => 'test', 'src' => 'http://www.youtube.com/test')));
+        $this->assertEquals(array('width' => '10', 'src' => 'https://www.youtube.com/test'), $filter->filter('iframe', array('width' => '10', 'src' => 'http://www.youtube.com/test')));
+        $this->assertEquals(array('src' => 'https://www.youtube.com/test'), $filter->filter('iframe', array('width' => 'test', 'src' => 'http://www.youtube.com/test')));
     }
 
     public function testRewriteProxyImageUrl()
@@ -125,7 +125,7 @@ class AttributeFilterTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($filter->filterIframeAttribute('iframe', 'src', '//www.youtube.com/test'));
         $this->assertFalse($filter->filterIframeAttribute('iframe', 'src', '//www.bidule.com/test'));
 
-        $this->assertEquals(array('src' => 'http://www.youtube.com/test'), $filter->filter('iframe', array('src' => '//www.youtube.com/test')));
+        $this->assertEquals(array('src' => 'https://www.youtube.com/test'), $filter->filter('iframe', array('src' => '//www.youtube.com/test')));
     }
 
     public function testFilterBlacklistAttribute()

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -71,10 +71,11 @@ class FilterTest extends PHPUnit_Framework_TestCase
     public function testOverrideFilters()
     {
         $data = '<iframe src="http://www.kickstarter.com/projects/lefnire/habitrpg-mobile/widget/video.html" height="480" width="640" frameborder="0"></iframe>';
+        $expected = '<iframe src="https://www.kickstarter.com/projects/lefnire/habitrpg-mobile/widget/video.html" height="480" width="640" frameborder="0"></iframe>';
 
         $f = Filter::html($data, 'http://blabla');
         $f->attribute->setIframeWhitelist(array('http://www.kickstarter.com'));
-        $this->assertEquals($data, $f->execute());
+        $this->assertEquals($expected, $f->execute());
 
         $data = '<iframe src="http://www.youtube.com/bla" height="480" width="640" frameborder="0"></iframe>';
 

--- a/tests/Filter/HtmlFilterTest.php
+++ b/tests/Filter/HtmlFilterTest.php
@@ -25,9 +25,10 @@ class HtmlFilterTest extends PHPUnit_Framework_TestCase
         $this->assertEmpty($f->execute());
 
         $data = '<iframe src="http://www.youtube.com/bla" height="480" width="640" frameborder="0"></iframe>';
+        $expected = '<iframe src="https://www.youtube.com/bla" height="480" width="640" frameborder="0"></iframe>';
 
         $f = new Html($data, 'http://blabla');
-        $this->assertEquals($data, $f->execute());
+        $this->assertEquals($expected, $f->execute());
     }
 
     public function testEmptyTags()
@@ -50,7 +51,7 @@ EOD;
         $data = '<iframe src="http://www.youtube.com/bla" height="480px" width="100%" frameborder="0"></iframe>';
 
         $f = new Html($data, 'http://blabla');
-        $this->assertEquals('<iframe src="http://www.youtube.com/bla" frameborder="0"></iframe>', $f->execute());
+        $this->assertEquals('<iframe src="https://www.youtube.com/bla" frameborder="0"></iframe>', $f->execute());
     }
 
     public function testRelativeScheme()


### PR DESCRIPTION
Linking https://github.com/owncloud/news/issues/734

To prevent active mixed content and MITM attacks for whitelisted iframes we should turn them http iframes' src attributes into their https equivalents. This is done for all whitelisted iframes and should work out of the box. 

I've used a whitelist before but it does not really make sense to allow insecure iframes which we are supposed to protect against so consider this a further lock down on security ;)