### PR TITLE
use item description if content contains only whitespaces

### DIFF
--- a/lib/PicoFeed/Parser/Rss20.php
+++ b/lib/PicoFeed/Parser/Rss20.php
@@ -208,7 +208,7 @@ class Rss20 extends Parser
     {
         $content = XmlParser::getNamespaceValue($entry, $this->namespaces, 'encoded');
 
-        if (empty($content) && $entry->description->count() > 0) {
+        if (trim($content) === '' && $entry->description->count() > 0) {
             $content = (string) $entry->description;
         }
 


### PR DESCRIPTION
Since XmlParser::getNamespaceValue returns always a string, there is not need to use ```empty()```.

Problematic example feed: http://www.allgemeine-zeitung.de/lokales/polizei/index.rss

//cc @Raydiation 

