### PR TITLE
@group online for tests failing without network

### DIFF
--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -6,6 +6,9 @@ use PHPUnit_Framework_TestCase;
 
 class ClientTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @group online
+     */
     public function testDownload()
     {
         $client = Client::getInstance();
@@ -20,6 +23,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
+     * @group online
      */
     public function testPassthrough()
     {
@@ -31,6 +35,9 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->expectOutputString(file_get_contents('tests/fixtures/miniflux_favicon.ico'));
     }
 
+    /**
+     * @group online
+     */
     public function testCacheBothHaveToMatch()
     {
         $client = Client::getInstance();
@@ -46,6 +53,9 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($client->isModified());
     }
 
+    /**
+     * @group online
+     */
     public function testCacheEtag()
     {
         $client = Client::getInstance();
@@ -63,6 +73,9 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($client->isModified());
     }
 
+    /**
+     * @group online
+     */
     public function testCacheLastModified()
     {
         $client = Client::getInstance();
@@ -78,6 +91,9 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($client->isModified());
     }
 
+    /**
+     * @group online
+     */
     public function testCacheBoth()
     {
         $client = Client::getInstance();
@@ -95,6 +111,9 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($client->isModified());
     }
 
+    /**
+     * @group online
+     */
     public function testCharset()
     {
         $client = Client::getInstance();
@@ -108,6 +127,9 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $client->getEncoding());
     }
 
+    /**
+     * @group online
+     */
     public function testContentType()
     {
         $client = Client::getInstance();

--- a/tests/Client/CurlTest.php
+++ b/tests/Client/CurlTest.php
@@ -6,6 +6,9 @@ use PHPUnit_Framework_TestCase;
 
 class CurlTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @group online
+     */
     public function testDownload()
     {
         $client = new Curl;
@@ -20,6 +23,7 @@ class CurlTest extends PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
+     * @group online
      */
     public function testPassthrough()
     {
@@ -31,6 +35,9 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $this->expectOutputString(file_get_contents('tests/fixtures/miniflux_favicon.ico'));
     }
 
+    /**
+     * @group online
+     */
     public function testRedirect()
     {
         $client = new Curl;
@@ -46,6 +53,7 @@ class CurlTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException PicoFeed\Client\InvalidCertificateException
+     * @group online
      */
     public function testSSL()
     {

--- a/tests/Client/GrabberTest.php
+++ b/tests/Client/GrabberTest.php
@@ -7,6 +7,9 @@ use PicoFeed\Reader\Reader;
 
 class GrabberTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @group online
+     */
     public function testGrabContentWithCandidates()
     {
         $grabber = new Grabber('http://theonion.com.feedsportal.com/c/34529/f/632231/s/309a7fe4/sc/20/l/0L0Stheonion0N0Carticles0Cobama0Ethrows0Eup0Eright0Ethere0Eduring0Esyria0Emeeting0H336850C/story01.htm');
@@ -37,6 +40,9 @@ class GrabberTest extends PHPUnit_Framework_TestCase
     }
 
     // 01net.com - https://github.com/fguillot/miniflux/issues/267
+    /**
+     * @group online
+     */
     public function testGetRules_afterRedirection()
     {
         $grabber = new Grabber('http://rss.feedsportal.com/c/629/f/502199/s/422f8c8a/sc/44/l/0L0S0A1net0N0Ceditorial0C640A3130Cces0E20A150Eimprimer0Eune0Epizza0Eet0Edes0Ebiscuits0Evideo0C0T0Dxtor0FRSS0E16/story01.htm');
@@ -44,6 +50,9 @@ class GrabberTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_array($grabber->getRules()));
     }
 
+    /**
+     * @group online
+     */
     public function testGrabContent()
     {
         $grabber = new Grabber('http://www.egscomics.com/index.php?id=1690');
@@ -53,6 +62,9 @@ class GrabberTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<img title="2013-08-22" src="comics/../comics/1377151029-2013-08-22.png" id="comic" border="0" />', $grabber->getContent());
     }
 
+    /**
+     * @group online
+     */
     public function testRssGrabContent()
     {
         $reader = new Reader;

--- a/tests/Client/StreamTest.php
+++ b/tests/Client/StreamTest.php
@@ -6,6 +6,9 @@ use PHPUnit_Framework_TestCase;
 
 class StreamTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @group online
+     */
     public function testChunkedResponse()
     {
         $client = new Stream;
@@ -15,6 +18,9 @@ class StreamTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('</rss>', substr($result['body'], -6));
     }
 
+    /**
+     * @group online
+     */
     public function testDownload()
     {
         $client = new Stream;
@@ -29,6 +35,7 @@ class StreamTest extends PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
+     * @group online
      */
     public function testPassthrough()
     {
@@ -40,6 +47,9 @@ class StreamTest extends PHPUnit_Framework_TestCase
         $this->expectOutputString(file_get_contents('tests/fixtures/miniflux_favicon.ico'));
     }
 
+    /**
+     * @group online
+     */
     public function testRedirect()
     {
         $client = new Stream;
@@ -64,6 +74,9 @@ class StreamTest extends PHPUnit_Framework_TestCase
         $client->doRequest();
     }
 
+    /**
+     * @group online
+     */
     public function testDecodeGzip()
     {
         if (function_exists('gzdecode')) {

--- a/tests/Reader/FaviconTest.php
+++ b/tests/Reader/FaviconTest.php
@@ -77,6 +77,9 @@ class FaviconTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $favicon->extract($html));
     }
 
+    /**
+     * @group online
+     */
     public function testExists()
     {
         $favicon = new Favicon;
@@ -87,6 +90,9 @@ class FaviconTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($favicon->exists(''));
     }
 
+    /**
+     * @group online
+     */
     public function testFind_inMeta()
     {
         $favicon = new Favicon;
@@ -123,6 +129,9 @@ class FaviconTest extends PHPUnit_Framework_TestCase
         $this->assertEmpty($favicon->getContent());
     }
 
+    /**
+     * @group online
+     */
     public function testFind_directLinkFirst()
     {
         $favicon = new Favicon;
@@ -135,6 +144,9 @@ class FaviconTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($favicon->getContent());
     }
 
+    /**
+     * @group online
+     */
     public function testFind_fallsBackToExtract()
     {
         $favicon = new Favicon;
@@ -146,6 +158,9 @@ class FaviconTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($favicon->getContent());
     }
 
+    /**
+     * @group online
+     */
     public function testDataUri()
     {
         $favicon = new Favicon;
@@ -160,6 +175,9 @@ class FaviconTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $favicon->getDataUri());
     }
 
+    /**
+     * @group online
+     */
     public function testDataUri_withBadContentType()
     {
         $favicon = new Favicon;

--- a/tests/Reader/ReaderTest.php
+++ b/tests/Reader/ReaderTest.php
@@ -15,6 +15,9 @@ class ReaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('https://google.com', $reader->prependScheme('https://google.com'));
     }
 
+    /**
+     * @group online
+     */
     public function testDownload_withHTTP()
     {
         $reader = new Reader;
@@ -22,6 +25,9 @@ class ReaderTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($feed);
     }
 
+    /**
+     * @group online
+     */
     public function testDownload_withHTTPS()
     {
         $reader = new Reader;
@@ -29,6 +35,9 @@ class ReaderTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($feed);
     }
 
+    /**
+     * @group online
+     */
     public function testDownload_withCache()
     {
         $reader = new Reader;
@@ -210,6 +219,9 @@ class ReaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $feeds);
     }
 
+    /**
+     * @group online
+     */
     public function testDiscover()
     {
         $reader = new Reader;


### PR DESCRIPTION
Tagging the tests using external network, so they can be simply excluded (e.g., via the `--exclude-group online` option of the `phpunit` CLI) when running them on a host without network access.