### PR TITLE
add setter to allow custom http request headers

### DIFF
--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -38,6 +38,14 @@ abstract class Client
     private $encoding = '';
 
     /**
+     * HTTP request headers
+     *
+     * @access protected
+     * @var array
+     */
+    protected $request_headers = array();
+
+    /**
      * HTTP Etag header
      *
      * @access protected
@@ -191,6 +199,16 @@ abstract class Client
         }
 
         throw new LogicException('You must have "allow_url_fopen=1" or curl extension installed');
+    }
+
+    /**
+     * Add HTTP Header to the request
+     *
+     * @access public
+     * @param array $headers
+     */
+    public function setHeaders($headers) {
+        $this->request_headers = $headers;
     }
 
     /**

--- a/lib/PicoFeed/Client/Curl.php
+++ b/lib/PicoFeed/Client/Curl.php
@@ -34,7 +34,7 @@ class Curl extends Client
      * @access private
      * @var array
      */
-    private $headers = array();
+    private $response_headers = array();
 
     /**
      * Counter on the number of header received
@@ -42,7 +42,7 @@ class Curl extends Client
      * @access private
      * @var integer
      */
-    private $headers_counter = 0;
+    private $response_headers_count = 0;
 
     /**
      * cURL callback to read the HTTP body
@@ -81,15 +81,15 @@ class Curl extends Client
         $length = strlen($buffer);
 
         if ($buffer === "\r\n") {
-            $this->headers_counter++;
+            $this->response_headers_count++;
         }
         else {
 
-            if (! isset($this->headers[$this->headers_counter])) {
-                $this->headers[$this->headers_counter] = '';
+            if (! isset($this->response_headers[$this->response_headers_count])) {
+                $this->response_headers[$this->response_headers_count] = '';
             }
 
-            $this->headers[$this->headers_counter] .= $buffer;
+            $this->response_headers[$this->response_headers_count] .= $buffer;
         }
 
         return $length;
@@ -152,6 +152,8 @@ class Curl extends Client
         if ($this->last_modified) {
             $headers[] = 'If-Modified-Since: '.$this->last_modified;
         }
+
+        $headers = array_merge($headers, $this->request_headers);
 
         return $headers;
     }
@@ -302,7 +304,7 @@ class Curl extends Client
     {
         $this->executeContext();
 
-        list($status, $headers) = HttpHeaders::parse(explode("\r\n", $this->headers[$this->headers_counter - 1]));
+        list($status, $headers) = HttpHeaders::parse(explode("\r\n", $this->response_headers[$this->response_headers_count - 1]));
 
         // When restricted with open_basedir
         if ($this->needToHandleRedirection($follow_location, $status)) {
@@ -343,8 +345,8 @@ class Curl extends Client
         $this->url = Url::resolve($location, $this->url);
         $this->body = '';
         $this->body_length = 0;
-        $this->headers = array();
-        $this->headers_counter = 0;
+        $this->response_headers = array();
+        $this->response_headers_count = 0;
 
         while (true) {
 
@@ -360,8 +362,8 @@ class Curl extends Client
                 $this->url = Url::resolve($result['headers']['Location'], $this->url);
                 $this->body = '';
                 $this->body_length = 0;
-                $this->headers = array();
-                $this->headers_counter = 0;
+                $this->response_headers = array();
+                $this->response_headers_count = 0;
             }
             else {
                 break;

--- a/lib/PicoFeed/Client/Stream.php
+++ b/lib/PicoFeed/Client/Stream.php
@@ -47,6 +47,8 @@ class Stream extends Client
             $headers[] = 'Authorization: Basic '.base64_encode($this->username.':'.$this->password);
         }
 
+        $headers = array_merge($headers, $this->request_headers);
+
         return $headers;
     }
 


### PR DESCRIPTION
I'm using picofeed to get content from the github api and creating an atom feed from the response.

The github API requires to use custom headers to specify the output format. This PR add the possible to specify custom request headers.

I've renamed the ```header``` property of the curl class to ```response_headers``` to avoid confusion between input and output headers.

/cc @Raydiation 