### PR TITLE
use setGrabber* only for the grabber configuration

### DIFF
--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -663,8 +663,8 @@ abstract class Client
     public function setConfig($config)
     {
         if ($config !== null) {
-            $this->setTimeout($config->getGrabberTimeout());
-            $this->setUserAgent($config->getGrabberUserAgent());
+            $this->setTimeout($config->getClientTimeout());
+            $this->setUserAgent($config->getClientUserAgent());
             $this->setMaxRedirections($config->getMaxRedirections());
             $this->setMaxBodySize($config->getMaxBodySize());
             $this->setProxyHostname($config->getProxyHostname());

--- a/lib/PicoFeed/Client/Grabber.php
+++ b/lib/PicoFeed/Client/Grabber.php
@@ -316,7 +316,13 @@ class Grabber
             try {
 
                 $client = Client::getInstance();
-                $client->setConfig($this->config);
+
+                if ($this->config !== null) {
+                    $client->setConfig($this->config);
+                    $client->setTimeout($this->config->getGrabberTimeout());
+                    $client->setUserAgent($this->config->getGrabberUserAgent());
+                }
+
                 $client->execute($this->url);
 
                 $this->url = $client->getUrl();


### PR DESCRIPTION
Use the values set with setClient* by default.

Overwrite setClient* values with setGrabber* values when within the Grabber class.

fixes #121 

@Raydiation