### PR TITLE
Enable the libxml entity loader after XXE scan

### DIFF
--- a/lib/PicoFeed/Parser/XmlParser.php
+++ b/lib/PicoFeed/Parser/XmlParser.php
@@ -55,7 +55,9 @@ class XmlParser
      */
     private static function scanInput($input, Closure $callback)
     {
-        if (substr(php_sapi_name(), 0, 3) === 'fpm') {
+        $isRunningFpm = substr(php_sapi_name(), 0, 3) === 'fpm';
+
+        if ($isRunningFpm) {
 
             // If running with PHP-FPM and an entity is detected we refuse to parse the feed
             // @see https://bugs.php.net/bug.php?id=64938
@@ -64,8 +66,7 @@ class XmlParser
             }
         }
         else {
-
-            libxml_disable_entity_loader(true);
+            $entityLoaderDisabled = libxml_disable_entity_loader(true);
         }
 
         libxml_use_internal_errors(true);
@@ -79,6 +80,10 @@ class XmlParser
                     return false;
                 }
             }
+        }
+
+        if ($isRunningFpm === false) {
+            libxml_disable_entity_loader($entityLoaderDisabled);
         }
 
         return $dom;


### PR DESCRIPTION
The `XmlParser` disables the `libxml` entity loader when running the XXE scan, which causes a [known bug in PHP](https://bugs.php.net/bug.php?id=62577). This meant that other libraries using XML files (such as Doctrine) are not able to load the XML files using `simplexml_load_file`.

By calling `libxml_disable_entity_loader(false)` before the `scanInput` method is returned, we enable the entity loader which allows other libraries to load external XML files.