### PR TITLE
Remove youtube autoplay from iframes

### DIFF
--- a/lib/PicoFeed/Filter/Attribute.php
+++ b/lib/PicoFeed/Filter/Attribute.php
@@ -235,6 +235,7 @@ class Attribute
         'filterProtocolUrlAttribute',
         'rewriteImageProxyUrl',
         'secureIframeSrc',
+        'removeYouTubeAutoplay'
     );
 
     /**
@@ -399,6 +400,25 @@ class Attribute
     {
         if ($tag === 'iframe' && $attribute === 'src' && strpos($value, 'http://') === 0) {
             $value = substr_replace($value, 's', 4, 0);
+        }
+
+        return true;
+    }
+
+    /**
+     * Removes YouTube autoplay from iframes
+     *
+     * @access public
+     * @param  string    $tag            Tag name
+     * @param  array     $attribute      Atttributes name
+     * @param  string    $value          Attribute value
+     * @return boolean
+     */
+    public function removeYouTubeAutoplay($tag, $attribute, &$value)
+    {
+        $regex = '%^(https://(?:www\.)?youtube.com/.*\?.*autoplay=)(1)(.*)%i';
+        if ($tag === 'iframe' && $attribute === 'src' && preg_match($regex, $value)) {
+            $value = preg_replace($regex, '${1}0$3', $value);
         }
 
         return true;

--- a/tests/Filter/AttributeFilterTest.php
+++ b/tests/Filter/AttributeFilterTest.php
@@ -128,6 +128,24 @@ class AttributeFilterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('src' => 'https://www.youtube.com/test'), $filter->filter('iframe', array('src' => '//www.youtube.com/test')));
     }
 
+    public function testRemoveYouTubeAutoplay()
+    {
+        $filter = new Attribute(new Url('http://google.com'));
+        $urls = array(
+            'https://www.youtube.com/something/?autoplay=1' => 'https://www.youtube.com/something/?autoplay=0',
+            'https://www.youtube.com/something/?test=s&autoplay=1&a=2' => 'https://www.youtube.com/something/?test=s&autoplay=0&a=2',
+            'https://www.youtube.com/something/?test=s' => 'https://www.youtube.com/something/?test=s',
+            'https://youtube.com/something/?autoplay=1' => 'https://youtube.com/something/?autoplay=0',
+            'https://youtube.com/something/?test=s&autoplay=1&a=2' => 'https://youtube.com/something/?test=s&autoplay=0&a=2',
+            'https://youtube.com/something/?test=s' => 'https://youtube.com/something/?test=s',
+        );
+
+        foreach ($urls as $before => $after) {
+            $filter->removeYouTubeAutoplay('iframe', 'src', $before);
+            $this->assertEquals($after, $before);
+        }
+    }
+
     public function testFilterBlacklistAttribute()
     {
         $filter = new Attribute(new Url('http://google.com'));


### PR DESCRIPTION
Youtube iframes can contain the ?autoplay=1 in the iframe URL which causes the video inside the iframe to autoplay. This is undesired behavior in regards to a feed reader, because all videos in your feed will start playing at once when you load a certain feed.