### PR TITLE
Replace multiple <br/><br/> by only one

### DIFF
--- a/lib/PicoFeed/Filter/Html.php
+++ b/lib/PicoFeed/Filter/Html.php
@@ -167,6 +167,7 @@ class Html
     {
         $this->output = $this->tag->removeEmptyTags($this->output);
         $this->output = $this->filterRules($this->output);
+        $this->output = $this->tag->removeMultipleTags($this->output);
         $this->output = trim($this->output);
     }
 

--- a/tests/Filter/HtmlFilterTest.php
+++ b/tests/Filter/HtmlFilterTest.php
@@ -164,4 +164,10 @@ x-amz-id-2: DDjqfqz2ZJufzqRAcj1mh+9XvSogrPohKHwXlo8IlkzH67G6w4wnjn9HYgbs4uI0
         $f = new Html('<table><tr></tr></table>', 'http://blabla');
         $this->assertEquals('', $f->execute());
     }
+
+    public function testRemoveMultipleTags()
+    {
+        $f = new Html('<br/><br/><p>toto</p><br/><br/><br/><p>momo</p><br/><br/><br/><br/>', 'http://blabla');
+        $this->assertEquals('<br/><p>toto</p><br/><p>momo</p><br/>', $f->execute());
+    }
 }


### PR DESCRIPTION
The call to the existing filter function was presumably accidentally
dropped with 2fe9778e783777b230486470c52d8c43a2979c69.

Without this filter at least feed items from heise.de and neowin.net
contain a lot of trailing ```<br/>```, which is nasty when using the full
items view of miniflux.

@Raydiation