### PR TITLE
code style changes

### DIFF
--- a/docs/grabber.markdown
+++ b/docs/grabber.markdown
@@ -97,11 +97,11 @@ Configuration
 ### Enable content grabber for items
 
 - Method name: `enableContentGrabber()`
-- Default value: true (also fetch content if rule does not exist)
-- Argument value: bool (true if also websites without rules should be grabbed)
+- Default value: false (also fetch content if no rule file exist)
+- Argument value: bool (true scrape only webpages which have a rule file)
 
 ```php
-$parser->enableContentGrabber(true);
+$parser->enableContentGrabber(false);
 ```
 
 ### Ignore item urls for the content grabber

--- a/docs/grabber.markdown
+++ b/docs/grabber.markdown
@@ -33,7 +33,7 @@ $grabber->execute();
 echo $grabber->getRawContent();
 
 // Get relevant content
-echo $grabber->getRelevantontent();
+echo $grabber->getRelevantContent();
 
 // Get filtered relevant content
 echo $grabber->getFilteredContent();

--- a/lib/PicoFeed/Filter/Html.php
+++ b/lib/PicoFeed/Filter/Html.php
@@ -167,7 +167,7 @@ class Html
     {
         $this->output = $this->tag->removeEmptyTags($this->output);
         $this->output = $this->filterRules($this->output);
-        $this->output = $this->tag->removeMultipleTags($this->output);
+        $this->output = $this->tag->removeMultipleBreakTags($this->output);
         $this->output = trim($this->output);
     }
 

--- a/lib/PicoFeed/Filter/Tag.php
+++ b/lib/PicoFeed/Filter/Tag.php
@@ -194,7 +194,7 @@ class Tag
      * @param  string  $data  Input data
      * @return string
      */
-    public function removeMultipleTags($data)
+    public function removeMultipleBreakTags($data)
     {
         return preg_replace("/(<br\s*\/?>\s*)+/", "<br/>", $data);
     }

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -87,8 +87,7 @@ abstract class Parser
      * @access private
      * @var bool
      */
-    private $enable_grabber_everywhere = false;
-
+    private $grabber_needs_rule_file = false;
 
     /**
      * Ignore those urls for the content scraper
@@ -249,7 +248,7 @@ abstract class Parser
             $grabber = new Scraper($this->config);
             $grabber->setUrl($item->getUrl());
 
-            if (! $this->enable_grabber_everywhere) {
+            if ($this->grabber_needs_rule_file) {
                 $grabber->disableCandidateParser();
             }
 
@@ -396,14 +395,14 @@ abstract class Parser
      * Enable the content grabber
      *
      * @access public
-     * @param bool $everywhere true if also pages without rules should be
+     * @param bool $needs_rule_file true if only pages with rule files should be
      * scraped
      * @return \PicoFeed\Parser\Parser
      */
-    public function enableContentGrabber($everywhere = true)
+    public function enableContentGrabber($needs_rule_file = false)
     {
         $this->enable_grabber = true;
-        $this->enable_grabber_everywhere = $everywhere;
+        $this->grabber_needs_rule_file = $needs_rule_file;
     }
 
     /**

--- a/lib/PicoFeed/Scraper/RuleParser.php
+++ b/lib/PicoFeed/Scraper/RuleParser.php
@@ -3,7 +3,6 @@
 namespace PicoFeed\Scraper;
 
 use DOMXPath;
-use PicoFeed\Logging\Logger;
 use PicoFeed\Parser\XmlParser;
 
 /**


### PR DESCRIPTION
Maybe a bit pedantic, but since we already agreed that the naming isn't optimal, we should take the opportunity to fix it.

The ```enableContentGrabber``` function has an inversed logic now.

@Raydiation 