### PR TITLE
more robust headers parsing

### DIFF
--- a/lib/PicoFeed/Client/Curl.php
+++ b/lib/PicoFeed/Client/Curl.php
@@ -80,7 +80,7 @@ class Curl extends Client
     {
         $length = strlen($buffer);
 
-        if ($buffer === "\r\n") {
+        if ($buffer === "\r\n" || $buffer === "\n") {
             $this->response_headers_count++;
         }
         else {
@@ -308,7 +308,7 @@ class Curl extends Client
     {
         $this->executeContext();
 
-        list($status, $headers) = HttpHeaders::parse(explode("\r\n", $this->response_headers[$this->response_headers_count - 1]));
+        list($status, $headers) = HttpHeaders::parse(explode("\n", $this->response_headers[$this->response_headers_count - 1]));
 
         // When restricted with open_basedir
         if ($this->needToHandleRedirection($follow_location, $status)) {


### PR DESCRIPTION
Don't force RFC2616 conform line endings, accept a single \n as well.
The carriage return is stripped by trim in HttpHeaders::parse anyway.

Fixes feed fetching from http://www.datatau.com/rss.

Follow-up from https://github.com/miniflux/miniflux/issues/367

/cc @Raydiation 