### PR TITLE
Fix PHP warning if channel node of a RSS 2.0 Feed is missing

### DIFF
--- a/lib/PicoFeed/Parser/Rss20.php
+++ b/lib/PicoFeed/Parser/Rss20.php
@@ -23,7 +23,13 @@ class Rss20 extends Parser
      */
     public function getItemsTree(SimpleXMLElement $xml)
     {
-        return $xml->channel->item;
+        $items = array();
+
+        if (isset($xml->channel->item)) {
+            $items = $xml->channel->item;
+        }
+
+        return $items;
     }
 
     /**


### PR DESCRIPTION
Normally SimpleXML returns an empty object for nodes which doesn't exist. But if the the parent of a requested node doesn't exists, a not iterable NULL is returned.

Fixes #152