### PR TITLE
suppress notice if encoding is unknown/unsupported

### DIFF
--- a/lib/PicoFeed/Encoding/Encoding.php
+++ b/lib/PicoFeed/Encoding/Encoding.php
@@ -16,6 +16,7 @@ class Encoding
         }
 
         // convert input to utf-8; ignore malformed characters
-        return iconv($encoding, 'UTF-8//IGNORE', $input);
+        // suppress notice if input encoding is unknown/unsupported
+        return @iconv($encoding, 'UTF-8//IGNORE', $input);
     }
 }


### PR DESCRIPTION
In PHP the iconv extension does not have a function to list all available
encodings, which can be checked against, to prevent this notice:

iconv(): Wrong charset, conversion from `input' to `output'.

fixes #154 