### PR TITLE
[RFC] add propper support of namespaces, use xPath for XML Parsing

### DIFF
--- a/lib/PicoFeed/Parser/Atom.php
+++ b/lib/PicoFeed/Parser/Atom.php
@@ -15,6 +15,18 @@ use PicoFeed\Client\Url;
 class Atom extends Parser
 {
     /**
+     * Register all supported namespaces
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @return SimpleXMLElement
+     */
+    public function registerSupportedNamespaces(SimpleXMLElement $xml)
+    {
+        return $xml;
+    }
+
+    /**
      * Get the path to the items XML tree
      *
      * @access public

--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -118,6 +118,8 @@ class Item
     /**
      * Get specific XML tag or attribute value
      *
+     * TODO: Add proper namespace support
+     *
      * @access public
      * @param  string  $tag           Tag name (examples: guid, media:content)
      * @param  string  $attribute     Tag attribute

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -141,6 +141,7 @@ abstract class Parser
         }
 
         $this->namespaces = $xml->getNamespaces(true);
+        $xml = $this->registerSupportedNamespaces($xml);
 
         $feed = new Feed;
 
@@ -159,6 +160,8 @@ abstract class Parser
         $this->findFeedIcon($xml, $feed);
 
         foreach ($this->getItemsTree($xml) as $entry) {
+
+            $entry = $this->registerSupportedNamespaces($entry);
 
             $item = new Item;
             $item->xml = $entry;
@@ -416,6 +419,15 @@ abstract class Parser
     {
         $this->grabber_ignore_urls = $urls;
     }
+
+    /**
+     * Register all supported namespaces
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @return SimpleXMLElement
+     */
+    public abstract function registerSupportedNamespaces(SimpleXMLElement $xml);
 
     /**
      * Find the feed url

--- a/lib/PicoFeed/Parser/Rss10.php
+++ b/lib/PicoFeed/Parser/Rss10.php
@@ -3,6 +3,7 @@
 namespace PicoFeed\Parser;
 
 use SimpleXMLElement;
+use PicoFeed\Filter\Filter;
 
 /**
  * RSS 1.0 parser
@@ -10,30 +11,131 @@ use SimpleXMLElement;
  * @author  Frederic Guillot
  * @package Parser
  */
-class Rss10 extends Rss20
+class Rss10 extends Parser
 {
+    /**
+     * Register all supported namespaces
+     *
+     * The default Namespace:
+     *   - RSS 1.0 (http://purl.org/rss/1.0/)
+     *
+     * Standard RSS 1.0 modules
+     *   - Dublin Core (http://purl.org/rss/1.0/modules/dc/)
+     *   - Content (http://purl.org/rss/1.0/modules/content/)
+     *
+     * Additionally we do support:
+     *   - Feedburner (http://rssnamespace.org/feedburner/ext/1.0)
+     *
+     * For broken feeds we do support
+     *   - Atom (http://www.w3.org/2005/Atom)
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @return SimpleXMLElement
+     */
+    public function registerSupportedNamespaces(SimpleXMLElement $xml)
+    {
+        $xml->registerXPathNamespace('rss', 'http://purl.org/rss/1.0/');
+        $xml->registerXPathNamespace('dc', 'http://purl.org/rss/1.0/modules/dc/');
+        $xml->registerXPathNamespace('content', 'http://purl.org/rss/1.0/modules/content/');
+        $xml->registerXPathNamespace('feedburner', 'http://rssnamespace.org/feedburner/ext/1.0');
+        $xml->registerXPathNamespace('atom', 'http://www.w3.org/2005/Atom');
+
+        return $xml;
+    }
+
     /**
      * Get the path to the items XML tree
      *
      * @access public
      * @param  SimpleXMLElement   $xml   Feed xml
-     * @return SimpleXMLElement
+     * @return SimpleXMLElement[]
      */
     public function getItemsTree(SimpleXMLElement $xml)
     {
-        return $xml->item;
+        return $xml->xpath('rss:item') ?: $xml->xpath('item');
     }
 
     /**
-     * Find the feed date
+     * Find the feed url
      *
      * @access public
-     * @param  SimpleXMLElement   $xml     Feed xml
+     * @param  SimpleXMLElement          $xml     Feed xml
      * @param  \PicoFeed\Parser\Feed     $feed    Feed object
      */
-    public function findFeedDate(SimpleXMLElement $xml, Feed $feed)
+    public function findFeedUrl(SimpleXMLElement $xml, Feed $feed)
     {
-        $feed->date = $this->date->getDateTime(XmlParser::getNamespaceValue($xml->channel, $this->namespaces, 'date'));
+        $feed->feed_url = '';
+    }
+
+    /**
+     * Find the site url
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @param  \PicoFeed\Parser\Feed     $feed    Feed object
+     */
+    public function findSiteUrl(SimpleXMLElement $xml, Feed $feed)
+    {
+        $site_url = $xml->xpath('rss:channel/rss:link') ?: $xml->xpath('channel/link');
+        $feed->site_url = (string) current($site_url);
+    }
+
+    /**
+     * Find the feed description
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @param  \PicoFeed\Parser\Feed     $feed    Feed object
+     */
+    public function findFeedDescription(SimpleXMLElement $xml, Feed $feed)
+    {
+        $description = $xml->xpath('rss:channel/rss:description')
+                ?: $xml->xpath('rss:channel/dc:description')
+                ?: $xml->xpath('channel/description');
+
+        $feed->description = (string) current($description);
+    }
+
+    /**
+     * Find the feed logo url
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @param  \PicoFeed\Parser\Feed     $feed    Feed object
+     */
+    public function findFeedLogo(SimpleXMLElement $xml, Feed $feed)
+    {
+        $logo = $xml->xpath('rss:image/rss:url') ?: $xml->xpath('image/url');
+        $feed->logo = (string) current($logo);
+    }
+
+    /**
+     * Find the feed icon
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @param  \PicoFeed\Parser\Feed     $feed    Feed object
+     */
+    public function findFeedIcon(SimpleXMLElement $xml, Feed $feed)
+    {
+        $feed->icon = '';
+    }
+
+    /**
+     * Find the feed title
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @param  \PicoFeed\Parser\Feed     $feed    Feed object
+     */
+    public function findFeedTitle(SimpleXMLElement $xml, Feed $feed)
+    {
+        $title = $xml->xpath('rss:channel/rss:title')
+                ?: $xml->xpath('rss:channel/dc:title')
+                ?: $xml->xpath('channel/title');
+
+        $feed->title = Filter::stripWhiteSpace((string) current($title)) ?: $feed->getSiteUrl();
     }
 
     /**
@@ -45,7 +147,134 @@ class Rss10 extends Rss20
      */
     public function findFeedLanguage(SimpleXMLElement $xml, Feed $feed)
     {
-        $feed->language = XmlParser::getNamespaceValue($xml->channel, $this->namespaces, 'language');
+        $language = $xml->xpath('rss:channel/dc:language') ?: $xml->xpath('channel/language');
+        $feed->language = (string) current($language);
+    }
+
+    /**
+     * Find the feed id
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @param  \PicoFeed\Parser\Feed     $feed    Feed object
+     */
+    public function findFeedId(SimpleXMLElement $xml, Feed $feed)
+    {
+        $feed->id = $feed->getFeedUrl() ?: $feed->getSiteUrl();
+    }
+
+    /**
+     * Find the feed date
+     *
+     * @access public
+     * @param  SimpleXMLElement   $xml     Feed xml
+     * @param  \PicoFeed\Parser\Feed     $feed    Feed object
+     */
+    public function findFeedDate(SimpleXMLElement $xml, Feed $feed)
+    {
+        $date = $xml->xpath('rss:channel/dc:date') ?: $xml->xpath('channel/date');
+        $feed->date = $this->date->getDateTime((string) current($date));
+    }
+
+    /**
+     * Find the item date
+     *
+     * @access public
+     * @param  SimpleXMLElement          $entry   Feed item
+     * @param  Item                      $item    Item object
+     * @param  \PicoFeed\Parser\Feed     $feed    Feed object
+     */
+    public function findItemDate(SimpleXMLElement $entry, Item $item, Feed $feed)
+    {
+        $date = $entry->xpath('dc:date') ?: $entry->xpath('date');
+
+        if (count($date) > 0) {
+            $date = $this->date->getDateTime((string) current($date));
+        }
+        else {
+            $date = $feed->getDate();
+        }
+
+        $item->date = $date;
+    }
+
+    /**
+     * Find the item title
+     *
+     * @access public
+     * @param  SimpleXMLElement          $entry   Feed item
+     * @param  \PicoFeed\Parser\Item     $item    Item object
+     */
+    public function findItemTitle(SimpleXMLElement $entry, Item $item)
+    {
+        // TODO: use $this->findItemUrl instead of $item->url; removes the
+        // depenency on call order and is more obvious
+        $title = $entry->xpath('rss:title')
+                ?: $entry->xpath('dc:title')
+                ?: $entry->xpath('title');
+
+        $item->title = Filter::stripWhiteSpace((string) current($title)) ?: (string) $item->url;
+    }
+
+    /**
+     * Find the item author
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed
+     * @param  SimpleXMLElement          $entry   Feed item
+     * @param  \PicoFeed\Parser\Item     $item    Item object
+     */
+    public function findItemAuthor(SimpleXMLElement $xml, SimpleXMLElement $entry, Item $item)
+    {
+        $author = $entry->xpath('dc:creator') ?: $entry->xpath('creator');
+
+        $item->author = (string) current($author);
+    }
+
+    /**
+     * Find the item content
+     *
+     * @access public
+     * @param  SimpleXMLElement          $entry   Feed item
+     * @param  \PicoFeed\Parser\Item     $item    Item object
+     */
+    public function findItemContent(SimpleXMLElement $entry, Item $item)
+    {
+        $content = $entry->xpath('content:encoded') ?: $entry->xpath('encoded');
+
+        if (trim((string) current($content)) === '') {
+            $content = $entry->xpath('rss:description')
+                    ?: $entry->xpath('dc:description')
+                    ?: $entry->xpath('description');
+        }
+
+        $item->content = (string) current($content);
+    }
+
+    /**
+     * Find the item URL
+     *
+     * @access public
+     * @param  SimpleXMLElement          $entry   Feed item
+     * @param  \PicoFeed\Parser\Item     $item    Item object
+     */
+    public function findItemUrl(SimpleXMLElement $entry, Item $item)
+    {
+        $links = $entry->xpath('rss:link')
+                ?: $entry->xpath('feedburner:origLink')
+                ?: $entry->xpath('atom:link/@href')
+                ?: $entry->xpath('link')
+                ?: $entry->xpath('origLink')
+                ?: $entry->xpath('link/@href');
+
+        foreach ($links as $link) {
+            $link = (string) $link;
+
+            if ($link !== '' && filter_var($link, FILTER_VALIDATE_URL) !== false) {
+                $item->url = $link;
+                break;
+            }
+        }
     }
 
     /**
@@ -58,9 +287,16 @@ class Rss10 extends Rss20
      */
     public function findItemId(SimpleXMLElement $entry, Item $item, Feed $feed)
     {
-        $item->id = $this->generateId(
-            $item->getTitle(), $item->getUrl(), $item->getContent()
-        );
+        $id = $entry->xpath('dc:identifier') ?: $entry->xpath('identifier') ;
+
+        if (count($id) > 0) {
+            $item->id = $this->generateId((string) current($id));
+        }
+        else {
+            $item->id = $this->generateId(
+                $item->getTitle(), $item->getUrl(), $item->getContent()
+            );
+        }
     }
 
     /**
@@ -73,5 +309,19 @@ class Rss10 extends Rss20
      */
     public function findItemEnclosure(SimpleXMLElement $entry, Item $item, Feed $feed)
     {
+    }
+
+    /**
+     * Find the item language
+     *
+     * @access public
+     * @param  SimpleXMLElement   $entry   Feed item
+     * @param  \PicoFeed\Parser\Item     $item    Item object
+     * @param  \PicoFeed\Parser\Feed     $feed    Feed object
+     */
+    public function findItemLanguage(SimpleXMLElement $entry, Item $item, Feed $feed)
+    {
+        $language = $entry->xpath('dc:language') ?: $entry->xpath('language');
+        $item->language = (string) current($language) ?: $feed->language;
     }
 }

--- a/lib/PicoFeed/Parser/Rss20.php
+++ b/lib/PicoFeed/Parser/Rss20.php
@@ -15,6 +15,18 @@ use PicoFeed\Client\Url;
 class Rss20 extends Parser
 {
     /**
+     * Register all supported namespaces
+     *
+     * @access public
+     * @param  SimpleXMLElement          $xml     Feed xml
+     * @return SimpleXMLElement
+     */
+    public function registerSupportedNamespaces(SimpleXMLElement $xml)
+    {
+        return $xml;
+    }
+
+    /**
      * Get the path to the items XML tree
      *
      * @access public

--- a/tests/Reader/ReaderTest.php
+++ b/tests/Reader/ReaderTest.php
@@ -231,7 +231,7 @@ class ReaderTest extends PHPUnit_Framework_TestCase
 
         $reader = new Reader;
         $client = $reader->discover('http://planete-jquery.fr');
-        $this->assertInstanceOf('PicoFeed\Parser\Rss20', $reader->getParser($client->getUrl(), $client->getContent(), $client->getEncoding()));
+        $this->assertInstanceOf('PicoFeed\Parser\Rss10', $reader->getParser($client->getUrl(), $client->getContent(), $client->getEncoding()));
 
         $reader = new Reader;
         $client = $reader->discover('http://cabinporn.com/');


### PR DESCRIPTION
Picofeed has only basic XML namespace support. This could result into situations where at least default namespaced - valid - atom or RSS 1.0 feeds couldn't be parsed. An example of such a feed is http://www.tandfonline.com/action/showFeed?ui=0&mi=h7u81o&ai=1g8&jc=rcel20&type=etoc&feed=rss.

Currently I'm rewriting the parser to support such feeds as well. I'm finished with the RSS 1.0 parser, but I'm interested in feedback before touching the other parser.

Is there anything I didn't took care of @Raydiation @fguillot? Any new bugs introduced? Did I reverted something that was added because of compatibility reasons or similar?

# Using xPath queries
The returned values of xPath queries are  more predictable. It's either an empty array or an array of not empty SimpleXMLElements. In case of a malformed xPath query, it's FALSE (which should be independent of user supplied content).

The SimpleXMLElement access object property notation returns in opposite:
  * empty object for elements which doesn't exist.
  * NULL if the the parent node of a requested element doesn't exist

Furthermore the namespace handling is way more easier and robust. If the feed uses namespaces without declaring them, the namespace prefix gets removed from nodes/elements and they are accessible like they never where namespaced.

## Possible incompatibilities

If a feed uses a wrong namespace uri, it's very likely that the namespaced nodes/elements aren't found any longer by picofeed. At the moment, default namespaces are ignored completely, so the namespace uri could be any string without the risk of trouble.

# Code simplification
the isset()'s aren't required since:
  * current returns FALSE if the array is empty and (string) of FALSE is an empty string
  * (string) of an empty SimpleXMLElement is an empty string
  * (string) of NULL is an empty string

# RSS 1.0 specific changes:

## Fixes
* feed logo: the image element is a child of the root node and not of the channel node

## Improvements
* feed title: use the "title" element of the Dublin Core module as last effort
* feed description: use the "description" element of the Dublin Core module as last effort
* item title: use the "title" element of the Dublin Core module as last effort
* item description: use the "description" element of the Dublin Core module as last effort
* item language: use the "language" element of the Dublin Core module as indicator for the item language instead of nothing

## Changes
* item id: use the Dublin Core "identifier" element as id (the Dublin Core module defines "identifier" as an "unambiguous reference to the resource)
* item date: none of the standard RSS 1.0 modules define a "pubDate" nor a "updated" item child element
* item author: none of the standard RSS 1.0 modules define a "author" nor a "webMaster" item child element

Sorry for creating a second PR. I've accidentally deleted the wrong branch, the PR got closed automatically and it's not possible to reopen the PR again.