### PR TITLE
Added the ability to limit the number of items to parse from the XML tree

### DIFF
--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -68,6 +68,14 @@ class Item
     public $date = null;
 
     /**
+     * Item raw content html
+     *
+     * @access public
+     * @var string
+     */
+    public $rawContent = '';
+
+    /**
      * Item content
      *
      * @access public
@@ -203,6 +211,17 @@ class Item
     public function getDate()
     {
         return $this->date;
+    }
+
+    /**
+     * Get raw content
+     *
+     * @access public
+     * $return string
+     */
+    public function getRawContent()
+    {
+        return $this->rawContent;
     }
 
     /**

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -98,12 +98,12 @@ abstract class Parser
     private $grabber_ignore_urls = array();
 
     /**
-     * Limit the number of items to parse from the tree
+     * Set the maximum number of items to parse from the tree
      *
      * @access private
-     * @var bool
+     * @var int
      */
-    private $limit_number_items_to_parse = 0;
+    private $max_items = -1;
 
     /**
      * Constructor
@@ -169,13 +169,11 @@ abstract class Parser
         $this->findFeedLogo($xml, $feed);
         $this->findFeedIcon($xml, $feed);
 
-        $indexItemTree = 0;
+        $itemsTree = $this->getItemsTree($xml);
 
-        foreach ($this->getItemsTree($xml) as $entry) {
+        for ($indexEntry = 0; $indexEntry < count($itemsTree) && $indexEntry < $this->max_items; $indexEntry++) {
 
-            if ($this->limit_number_items_to_parse && $indexItemTree == $this->limit_number_items_to_parse) {
-                break;
-            }
+            $entry = $itemsTree[$indexEntry];
 
             $item = new Item;
             $item->xml = $entry;
@@ -201,7 +199,6 @@ abstract class Parser
             $this->scrapWebsite($item);
 
             $feed->items[] = $item;
-            $indexItemTree++;
         }
 
         Logger::setMessage(get_called_class().PHP_EOL.$feed);
@@ -436,15 +433,15 @@ abstract class Parser
     }
 
     /**
-     * Set the limit of number of items to parse. Limit is active if bigger than 0.
+     * Set the maximum number of items to parse. Limit is active if positive.
      *
      * @access public
-     * @param  bool  $limit   Number
+     * @param  int  $maxItems   Number
      * @return \PicoFeed\Parser\Parser
      */
-    public function setLimitNumberItemsToParse($limit)
+    public function setMaximumNumberItemsToParse($maxItems)
     {
-        $this->limit_number_items_to_parse = $limit;
+        $this->max_items = $maxItems;
         return $this;
     }
 

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -171,7 +171,9 @@ abstract class Parser
 
         $itemsTree = $this->getItemsTree($xml);
 
-        for ($indexEntry = 0; $indexEntry < count($itemsTree) && $indexEntry < $this->max_items; $indexEntry++) {
+        for ($indexEntry = 0;
+             $indexEntry < count($itemsTree) && ($this->max_items == -1 || $indexEntry < $this->max_items);
+             $indexEntry++) {
 
             $entry = $itemsTree[$indexEntry];
 

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -98,6 +98,14 @@ abstract class Parser
     private $grabber_ignore_urls = array();
 
     /**
+     * Limit the number of items to parse from the tree
+     *
+     * @access private
+     * @var bool
+     */
+    private $limit_number_items_to_parse = 0;
+
+    /**
      * Constructor
      *
      * @access public
@@ -161,7 +169,13 @@ abstract class Parser
         $this->findFeedLogo($xml, $feed);
         $this->findFeedIcon($xml, $feed);
 
+        $indexItemTree = 0;
+
         foreach ($this->getItemsTree($xml) as $entry) {
+
+            if ($this->limit_number_items_to_parse && $indexItemTree == $this->limit_number_items_to_parse) {
+                break;
+            }
 
             $item = new Item;
             $item->xml = $entry;
@@ -187,6 +201,7 @@ abstract class Parser
             $this->scrapWebsite($item);
 
             $feed->items[] = $item;
+            $indexItemTree++;
         }
 
         Logger::setMessage(get_called_class().PHP_EOL.$feed);
@@ -418,6 +433,19 @@ abstract class Parser
     public function setGrabberIgnoreUrls(array $urls)
     {
         $this->grabber_ignore_urls = $urls;
+    }
+
+    /**
+     * Set the limit of number of items to parse. Limit is active if bigger than 0.
+     *
+     * @access public
+     * @param  bool  $limit   Number
+     * @return \PicoFeed\Parser\Parser
+     */
+    public function setLimitNumberItemsToParse($limit)
+    {
+        $this->limit_number_items_to_parse = $limit;
+        return $this;
     }
 
     /**

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -272,6 +272,7 @@ abstract class Parser
             $grabber->execute();
 
             if ($grabber->hasRelevantContent()) {
+                $item->rawContent = $grabber->getRawContent();
                 $item->content = $grabber->getFilteredContent();
             }
         }


### PR DESCRIPTION
I have added the Parser option to limit the number of items to parse in the XML tree. So when the items tree is too big, we can stop before. By default it's disabled.

I am using this library in my product.
I use the content-grabber option, so the time it takes to get all the items in the tree is considerable.

I was parsing this feed `http://www.sketchappsources.com/rss.xml` that has 1325 items in the tree. Well it  doesn't end parsing, because it takes way too long.
With the limit option I can limit the number of items parsed to something more reasonable.
