### PR TITLE
Fixed documentation in Item.php

### DIFF
--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -198,7 +198,7 @@ class Item
      * Get date
      *
      * @access public
-     * $return integer
+     * $return \DateTime
      */
     public function getDate()
     {


### PR DESCRIPTION
getDate() return type was still said to be integer