### PR TITLE
Revert "rules: include explosm filename"

### DIFF
--- a/lib/PicoFeed/Rules/explosm.net.php
+++ b/lib/PicoFeed/Rules/explosm.net.php
@@ -5,7 +5,6 @@ return array(
             'test_url' => 'http://explosm.net/comics/3803/',
             'body' => array(
                 '//div[@id="comic-container"]',
-                '//div[@id="comic-container"]//img/@src'
             ),
             'strip' => array(
             ),


### PR DESCRIPTION
This reverts commit c7085c4a533990f39eec139e6bfa70a885fbcd78.

Fixes  #181