### PR TITLE
Update .phoronix.com.php

### DIFF
--- a/lib/PicoFeed/Rules/.phoronix.com.php
+++ b/lib/PicoFeed/Rules/.phoronix.com.php
@@ -4,7 +4,7 @@ return array(
         '%.*%' => array(
             'test_url' => 'http://www.phoronix.com/scan.php?page=article&item=amazon_ec2_bare&num=1',
             'body' => array(
-                '//div[@class="KonaBody"]',
+                '//div[@class="content"]',
             ),
             'strip' => array()
         )


### PR DESCRIPTION
Hello,

I push an updated rule following last month's [new site](http://www.phoronix.com/scan.php?page=news_item&px=New-10-Site-Is-Live).

Before:
[2015-08-17 08:26:54] PicoFeed\Scraper\RuleLoader Load rule: .phoronix.com
[2015-08-17 08:26:54] PicoFeed\Scraper\Scraper: Parse content with rules
[2015-08-17 08:26:54] PicoFeed\Scraper\Scraper: Matched url /scan.php?page=article&item=pny-cs1211-ssd&num=1
[2015-08-17 08:26:54] PicoFeed\Scraper\Scraper: Content length: **0** bytes

After:
[2015-08-17 08:30:40] PicoFeed\Scraper\RuleLoader Load rule: .phoronix.com
[2015-08-17 08:30:40] PicoFeed\Scraper\Scraper: Parse content with rules
[2015-08-17 08:30:40] PicoFeed\Scraper\Scraper: Matched url /scan.php?page=article&item=pny-cs1211-ssd&num=1
[2015-08-17 08:30:40] PicoFeed\Scraper\Scraper: Content length: **2518** bytes
[2015-08-17 08:30:40] PicoFeed\Scraper\RuleLoader Load rule: .phoronix.com

FYI, without specific rule, it matches div class "after-article":
[2015-08-17 08:31:29] PicoFeed\Scraper\Scraper: Parse content with candidates
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "articleBody"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "articlebody"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "article-body"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "articleContent"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "articlecontent"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "article-content"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "articlePage"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "post-content"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "post_content"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "entry-content"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "entry-body"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "main-content"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "story_content"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "storycontent"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "entryBox"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "entrytext"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "comic"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "post"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Try this candidate: "article"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Find candidate "article"
[2015-08-17 08:31:29] PicoFeed\Scraper\CandidateParser: Strip tag: "header"
[2015-08-17 08:31:29] PicoFeed\Scraper\Scraper: Content length: 1948 bytes