### PR TITLE
Require config as tag constructor parameter

### DIFF
--- a/lib/PicoFeed/Filter/Html.php
+++ b/lib/PicoFeed/Filter/Html.php
@@ -88,9 +88,10 @@ class Html
      */
     public function __construct($html, $website)
     {
+        $this->config = new Config;
         $this->input = XmlParser::HtmlToXml($html);
         $this->output = '';
-        $this->tag = new Tag;
+        $this->tag = new Tag($this->config);
         $this->website = $website;
         $this->attribute = new Attribute(new Url($website));
     }

--- a/lib/PicoFeed/Filter/Tag.php
+++ b/lib/PicoFeed/Filter/Tag.php
@@ -3,7 +3,9 @@
 namespace PicoFeed\Filter;
 
 use DOMXpath;
+
 use PicoFeed\Parser\XmlParser;
+use PicoFeed\Config\Config;
 
 /**
  * Tag Filter class
@@ -13,6 +15,14 @@ use PicoFeed\Parser\XmlParser;
  */
 class Tag
 {
+    /**
+     * Config object
+     *
+     * @access private
+     * @var \PicoFeed\Config\Config
+     */
+    private $config;
+
     /**
      * Tags blacklist (Xpath expressions)
      *
@@ -70,6 +80,11 @@ class Tag
         'iframe',
         'q',
     );
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
 
     /**
      * Check if the tag is allowed and is not a pixel tracker
@@ -130,7 +145,10 @@ class Tag
      */
     public function isAllowedTag($tag)
     {
-        return in_array($tag, $this->tag_whitelist);
+        return in_array($tag, array_merge(
+            $this->tag_whitelist,
+            array_keys($this->config->getFilterWhitelistedTags(array()))
+        ));
     }
 
     /**

--- a/tests/Filter/TagFilterTest.php
+++ b/tests/Filter/TagFilterTest.php
@@ -3,12 +3,13 @@ namespace PicoFeed\Filter;
 
 use PHPUnit_Framework_TestCase;
 
+use PicoFeed\Config\Config;
 
 class TagFilterTest extends PHPUnit_Framework_TestCase
 {
     public function testAllowedTag()
     {
-        $tag = new Tag;
+        $tag = new Tag(new Config);
 
         $this->assertTrue($tag->isAllowed('p', array('class' => 'test')));
         $this->assertTrue($tag->isAllowed('img', array('class' => 'test')));
@@ -19,7 +20,7 @@ class TagFilterTest extends PHPUnit_Framework_TestCase
 
     public function testHtml()
     {
-        $tag = new Tag;
+        $tag = new Tag(new Config);
 
         $this->assertEquals('<p>', $tag->openHtmlTag('p'));
         $this->assertEquals('<img src="test" alt="truc"/>', $tag->openHtmlTag('img', 'src="test" alt="truc"'));


### PR DESCRIPTION
First step to fix #194 

This will take more time since state is **EVERYWHERE** in the filters and needs to be factored out. I've started and drowned in changes and breaking unit tests, so we need to do this gradually :)