### PR TITLE
update rules for bbc, npr, wired

### DIFF
--- a/lib/PicoFeed/Rules/.wired.com.php
+++ b/lib/PicoFeed/Rules/.wired.com.php
@@ -4,10 +4,16 @@ return array(
         '%.*%' => array(
             'test_url' => 'http://www.wired.com/gamelife/2013/09/ouya-free-the-games/',
             'body' => array(
-                 '//div[@class="entry"]',
+                 '//div[@data-js="gallerySlides"]',
+                 '//article',
             ),
             'strip' => array(
                 '//*[@id="linker_widget"]',
+                '//*[@class="credit"]',
+                '//div[@data-js="slideCount"]',
+                '//span[@class="visually-hidden"]',
+                '//*[@data-slide-number="_endslate"]',
+                '//*[@id="related"]',
                 '//*[contains(@class, "bio")]',
                 '//*[contains(@class, "entry-footer")]',
                 '//*[contains(@class, "mobify_backtotop_link")]',
@@ -15,7 +21,11 @@ return array(
                 '//*[contains(@class, "gallery-thumbnail")]',
                 '//img[contains(@src, "1x1")]',
                 '//a[contains(@href, "creativecommons")]',
+                '//a[@href="#start-of-content"]',
+                '//ul[@id="article-tags"],
             ),
         )
     )
 );
+
+

--- a/lib/PicoFeed/Rules/bizjournals.com.php
+++ b/lib/PicoFeed/Rules/bizjournals.com.php
@@ -4,8 +4,8 @@ return array(
         '%.*%' => array(
             'test_url' => 'http://www.bizjournals.com/milwaukee/news/2015/09/30/bucks-will-hike-prices-on-best-seats-at-new-arena.html',
             'body' => array(
-            '//figure/div/a/img',
             '//p[@class="media__caption"]',
+            '//figure/div/a/img',
             '//p[@class="content__segment"]',
             ),
         )

--- a/lib/PicoFeed/Rules/www.bbc.co.uk.php
+++ b/lib/PicoFeed/Rules/www.bbc.co.uk.php
@@ -4,16 +4,24 @@ return array(
         '%.*%' => array(
             'test_url' => 'http://www.bbc.co.uk/news/world-middle-east-23911833',
             'body' => array(
-                '//div[@class="story-body"]',
+                '//div[@class="story-body__inner"] | //div[@class="article"]',
                 '//div[@class="indPost"]'
             ),
             'strip' => array(
                 '//form',
+		'//div[@id="headline"]',
                 '//*[@class="warning"]',
+                '//span[@class="off-screen"]',
+                '//span[@class="story-image-copyright"]',
+                '//div[@class="ad_wrapper"]',
+                '//div[@id="article-sidebar"]',
+		'//div[@class="data-table-outer"]',
                 '//*[@class="story-date"]',
                 '//*[@class="story-header"]',
+                '//figure[contains(@class,"has-caption")]',
                 '//*[@class="story-related"]',
                 '//*[contains(@class, "byline")]',
+                '//p[contains(@class, "media-message")]',
                 '//*[contains(@class, "story-feature")]',
                 '//*[@id="video-carousel-container"]',
                 '//*[@id="also-related-links"]',

--- a/lib/PicoFeed/Rules/www.npr.org.php
+++ b/lib/PicoFeed/Rules/www.npr.org.php
@@ -9,7 +9,9 @@ return array(
             'strip' => array(
                 '//*[@class="bucket img"]',
                 '//*[@class="creditwrap"]',
+                '//*[@class="credit"]',
                 '//*[@class="captionwrap"]',
+                '//*[@class="toggle-caption"]',
                 '//*[contains(@class, "enlargebtn")]',
             ),
         )


### PR DESCRIPTION
Changed a few rules.  Added to the strip array one item for NPR.  Changed a little for bbc.  For wired, changed things around so that the full gallery of images is pulled and cleaned up displaying just the information from the caption for each.