### PR TITLE
Do not string compare for fixed php versions on php-fpm

### DIFF
--- a/lib/PicoFeed/Parser/XmlParser.php
+++ b/lib/PicoFeed/Parser/XmlParser.php
@@ -42,6 +42,19 @@ class XmlParser
     }
 
     /**
+     * @return true if it a vulnerable php-fpm version is used
+     */
+    public static function isRunningVulnerableFpm()
+    {
+        $isUnpatched = version_compare(PHP_VERSION, '5.5.22', 'lt') || (
+            version_compare(PHP_VERSION, '5.6', 'gte') &&
+            version_compare(PHP_VERSION, '5.6.6', 'lt')
+        );
+
+        return substr(php_sapi_name(), 0, 3) === 'fpm' && $isUnpatched;
+    }
+
+    /**
      * Scan the input for XXE attacks.
      *
      * @param string  $input    Unsafe input
@@ -53,7 +66,7 @@ class XmlParser
      */
     private static function scanInput($input, Closure $callback)
     {
-        $isRunningFpm = substr(php_sapi_name(), 0, 3) === 'fpm';
+        $isRunningFpm = self::isRunningVulnerableFpm();
 
         if ($isRunningFpm) {
 

--- a/lib/PicoFeed/Parser/XmlParser.php
+++ b/lib/PicoFeed/Parser/XmlParser.php
@@ -44,14 +44,14 @@ class XmlParser
     /**
      * @return true if it a vulnerable php-fpm version is used
      */
-    public static function isRunningVulnerableFpm()
+    private static function isRunningVulnerableFpm()
     {
-        $isUnpatched = version_compare(PHP_VERSION, '5.5.22', 'lt') || (
+        $isUnpatchedPhp = version_compare(PHP_VERSION, '5.5.22', 'lt') || (
             version_compare(PHP_VERSION, '5.6', 'gte') &&
             version_compare(PHP_VERSION, '5.6.6', 'lt')
         );
 
-        return substr(php_sapi_name(), 0, 3) === 'fpm' && $isUnpatched;
+        return substr(php_sapi_name(), 0, 3) === 'fpm' && $isUnpatchedPhp;
     }
 
     /**


### PR DESCRIPTION
The PHP FPM issue was fixed in PHP versions >5.2.22 and >5.6.6: https://bugs.php.net/bug.php?id=64938

Your parser however is still vulnerable to [ZF2015-06]