### PR TITLE
It is now possible to serialize a Feed object, e.g. for caching purposes

### DIFF
--- a/lib/PicoFeed/Client/Curl.php
+++ b/lib/PicoFeed/Client/Curl.php
@@ -40,6 +40,13 @@ class Curl extends Client
     private $response_headers_count = 0;
 
     /**
+     * Redirect count, registered for every url
+     *
+     * @var array
+     */
+    private $nb_redirects = array();
+
+    /**
      * cURL callback to read the HTTP body.
      *
      * If the function return -1, curl stop to read the HTTP response
@@ -309,18 +316,23 @@ class Curl extends Client
      */
     private function handleRedirection($location)
     {
-        $nb_redirects = 0;
         $result = array();
         $this->url = Url::resolve($location, $this->url);
+
+        if (!isset($this->nb_redirects[$this->url]))
+        {
+            $this->nb_redirects[$this->url] = 0;
+        }
+
         $this->body = '';
         $this->body_length = 0;
         $this->response_headers = array();
         $this->response_headers_count = 0;
 
         while (true) {
-            ++$nb_redirects;
+            ++$this->nb_redirects[$this->url];
 
-            if ($nb_redirects >= $this->max_redirects) {
+            if ($this->nb_redirects[$this->url] >= $this->max_redirects) {
                 throw new MaxRedirectException('Maximum number of redirections reached');
             }
 

--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -254,17 +254,7 @@ class Item
     {
         if ($this->xml)
         {
-            $xml = XmlParser::getSimpleXml($this->xml);
-
-            if (is_array($this->namespaces))
-            {
-                foreach ($this->namespaces as $prefix => $ns)
-                {
-                    $xml->registerXPathNamespace($prefix, $ns);
-                }
-            }
-
-            $this->xml = $xml;
+            $this->xml = XmlParser::getSimpleXml($this->xml);
         }
         else
         {

--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -12,7 +12,8 @@ class Item
     /**
      * List of known RTL languages.
      *
-     * @var public
+     * @public
+     * @var array
      */
     public $rtl = array(
         'ar',  // Arabic (ar-**)
@@ -226,5 +227,46 @@ class Item
     public function isRTL()
     {
         return Parser::isLanguageRTL($this->language);
+    }
+
+    /**
+     * @return string
+     */
+    public function serialize()
+    {
+        $this->xml = (string) $this->xml;
+
+        return serialize($this);
+    }
+
+    /**
+     * @param string $data
+     */
+    public function unserialize($data)
+    {
+        if ($data)
+        {
+            /**
+             * @var $feed Item
+             */
+            $item = unserialize($data);
+
+            if (is_a($item, 'PicoFeed\\Parser\\Item'))
+            {
+                $this->author         = $item->author;
+                $this->url            = $item->url;
+                $this->content        = $item->content;
+                $this->date           = $item->date;
+                $this->enclosure_type = $item->enclosure_type;
+                $this->enclosure_url  = $item->enclosure_url;
+                $this->rtl            = $item->rtl;
+                $this->id             = $item->id;
+                $this->language       = $item->language;
+                $this->namespaces     = $item->namespaces;
+                $this->title          = $item->title;
+
+                $this->xml = new \SimpleXMLElement($item->xml);
+            }
+        }
     }
 }

--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -239,9 +239,9 @@ class Item
      */
     public function __sleep()
     {
-        if ($this->xml)
+        if ($this->xml instanceof \SimpleXMLElement)
         {
-            $this->xml = (string) $this->xml;
+            $this->xml = $this->xml->asXML();
         }
 
         return array_keys(get_object_vars($this));
@@ -252,13 +252,23 @@ class Item
      */
     public function __wakeup()
     {
-        if (trim($this->xml))
+        if ($this->xml)
         {
-            $this->xml = new \SimpleXMLElement($this->xml);
+            $xml = XmlParser::getSimpleXml($this->xml);
+
+            if (is_array($this->namespaces))
+            {
+                foreach ($this->namespaces as $prefix => $ns)
+                {
+                    $xml->registerXPathNamespace($prefix, $ns);
+                }
+            }
+
+            $this->xml = $xml;
         }
         else
         {
-            $this->xml = null;
+            $this->xml = NULL;
         }
     }
 }

--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -113,6 +113,8 @@ class Item
      */
     public function getTag($tag, $attribute = '')
     {
+        if (!($this->xml instanceof \SimpleXMLElement)) return false;
+
         // convert to xPath attribute query
         if ($attribute !== '') {
             $attribute = '/@'.$attribute;
@@ -253,6 +255,10 @@ class Item
         if (trim($this->xml))
         {
             $this->xml = new \SimpleXMLElement($this->xml);
+        }
+        else
+        {
+            $this->xml = null;
         }
     }
 }

--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -230,43 +230,29 @@ class Item
     }
 
     /**
-     * @return string
+     * Sleep method is used to transfor the SimpleXML (resource) back to it's original string,
+     * so that a deserialization can re-create a fresh new SimpleXMLElement instance
+     *
+     * @return array
      */
-    public function serialize()
+    public function __sleep()
     {
-        $this->xml = (string) $this->xml;
+        if ($this->xml)
+        {
+            $this->xml = (string) $this->xml;
+        }
 
-        return serialize($this);
+        return array_keys(get_object_vars($this));
     }
 
     /**
-     * @param string $data
+     * Wakeup call to re-establish unserialized xml data to a SimpleXMLElement instance
      */
-    public function unserialize($data)
+    public function __wakeup()
     {
-        if ($data)
+        if (trim($this->xml))
         {
-            /**
-             * @var $feed Item
-             */
-            $item = unserialize($data);
-
-            if (is_a($item, 'PicoFeed\\Parser\\Item'))
-            {
-                $this->author         = $item->author;
-                $this->url            = $item->url;
-                $this->content        = $item->content;
-                $this->date           = $item->date;
-                $this->enclosure_type = $item->enclosure_type;
-                $this->enclosure_url  = $item->enclosure_url;
-                $this->rtl            = $item->rtl;
-                $this->id             = $item->id;
-                $this->language       = $item->language;
-                $this->namespaces     = $item->namespaces;
-                $this->title          = $item->title;
-
-                $this->xml = new \SimpleXMLElement($item->xml);
-            }
+            $this->xml = new \SimpleXMLElement($this->xml);
         }
     }
 }

--- a/tests/Serialization/SerializeTest.php
+++ b/tests/Serialization/SerializeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PicoFeed\Serialization;
+
+use PHPUnit_Framework_TestCase;
+use PicoFeed\Parser\Rss20;
+
+class SerializeTest
+    extends PHPUnit_Framework_TestCase
+{
+    public function testSerialization()
+    {
+        $parser = new Rss20(file_get_contents('tests/fixtures/podbean.xml'));
+        $feed   = $parser->execute();
+
+        $this->assertEquals(serialize($feed), file_get_contents('tests/fixtures/podbean.xml.serialized'));
+    }
+
+    public function testUnserialization()
+    {
+        $parser           = new Rss20(file_get_contents('tests/fixtures/podbean.xml'));
+        $feed             = $parser->execute();
+        $feedUnserialized = unserialize(file_get_contents('tests/fixtures/podbean.xml.serialized'));
+
+        foreach ($feed->items as $index => $item)
+        {
+            foreach ($item as $key => $value)
+            {
+                if ($key !== 'xml')
+                {
+                    $this->assertEquals($value, $feedUnserialized->items[$index]->$key);
+                }
+                else
+                {
+                    $this->assertEquals($value, $feedUnserialized->items[$index]->xml);
+                }
+            }
+        }
+
+        $this->assertEquals($feed->date, $feedUnserialized->date);
+        $this->assertEquals($feed->description, $feedUnserialized->description);
+        $this->assertEquals($feed->feed_url, $feedUnserialized->feed_url);
+        $this->assertEquals($feed->icon, $feedUnserialized->icon);
+        $this->assertEquals($feed->id, $feedUnserialized->id);
+        $this->assertEquals($feed->language, $feedUnserialized->language);
+        $this->assertEquals($feed->logo, $feedUnserialized->logo);
+        $this->assertEquals($feed->site_url, $feedUnserialized->site_url);
+        $this->assertEquals($feed->title, $feedUnserialized->title);
+    }
+}

--- a/tests/Serialization/SerializeTest.php
+++ b/tests/Serialization/SerializeTest.php
@@ -20,7 +20,10 @@ class SerializeTest
     {
         $parser           = new Rss20(file_get_contents('tests/fixtures/podbean.xml'));
         $feed             = $parser->execute();
-        $feedUnserialized = unserialize(file_get_contents('tests/fixtures/podbean.xml.serialized'));
+
+        $parser2           = new Rss20(file_get_contents('tests/fixtures/podbean.xml'));
+        $feed2             = $parser2->execute();
+        $feedUnserialized = unserialize(serialize($feed2));
 
         foreach ($feed->items as $index => $item)
         {
@@ -32,7 +35,10 @@ class SerializeTest
                 }
                 else
                 {
-                    $this->assertEquals($value, $feedUnserialized->items[$index]->xml);
+                    $this->assertEquals(
+                        trim(html_entity_decode(preg_replace("/U\+([0-9A-F]{4})/", "&#x\\1;", str_replace('<?xml version="1.0"?>', '', $value->asXML())), ENT_NOQUOTES, 'UTF-8')),
+                        trim(html_entity_decode(preg_replace("/U\+([0-9A-F]{4})/", "&#x\\1;", str_replace('<?xml version="1.0"?>', '', $feedUnserialized->items[$index]->xml->asXML())), ENT_NOQUOTES, 'UTF-8'))
+                    );
                 }
             }
         }

--- a/tests/fixtures/podbean.xml.serialized
+++ b/tests/fixtures/podbean.xml.serialized
@@ -1,0 +1,1122 @@
+O:20:"PicoFeed\Parser\Feed":10:{s:5:"items";a:50:{i:0;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"f57f596818708149e9e26ccf56785ecd0e849be037de40b9961ec6c749317ef3";s:5:"title";s:26:"S03E11: Finding Nemo-rocco";s:3:"url";s:61:"http://aroundthebloc.podbean.com/e/s03e11-finding-nemo-rocco/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-16 12:56:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:579:"The Wanderers this week played in the club world cup, where they came off the pitch squeaky clean due to the weather, but couldn’t keep their sheet in the same condition and missed out on their dream match with Real Madrid. The team now goes on to contest the fifth place playoff against Algerian team ES Setif, who we hope gets ES se-mashed.
+
+With mostly away games coming up, we’ve got details of how the RBB will be getting behind Nato - flag making and waving extraordinaire - who’s having a rough time, as well as all the usual stuff as well.
+
+This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/xb5pjd/S03E11_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:1;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"086b4e30d607581a998514246ca35e348d3650796b6cea93a5313602893ee02b";s:5:"title";s:32:"S03E10: No Money, Mo’ Problems";s:3:"url";s:63:"http://aroundthebloc.podbean.com/e/s03e10-no-money-mo-problems/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-09 13:20:39.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:490:"Well, the Wanderers lost two games in the last week, and to top it off, the players are having issues with the clubs owners about their bonuses for playing in the Club World Cup… That’s right, the Wanderers are playing in the Club World Cup! We start off against a Mexican team, once we Cruz through them, things will get Real… really Real. After we Bale them over, we’ve got one game to win before we’re champions of the world.
+
+Easier said than won eh?
+
+This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/h6ifqz/S03E10_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:2;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"c513e75f5e4722eb556fc72dac3bb88fd27e9a3e20be5591819d57f2b026af04";s:5:"title";s:14:"S03E09: K-Gate";s:3:"url";s:49:"http://aroundthebloc.podbean.com/e/s03e09-k-gate/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-02 13:47:31.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:629:"<p>The second derby of the season has come and gone, and the Cove and the RBB were both fans of the team that didn’t win. Tomi Gun’s goal was cancelled out by a screamer from Ibini, and the Wanderers winless and undefeated streaks continue.</p>
+
+<p>The club did, however, perform well at the AFC Awards night, winning Club and Coach of the Year. We lost in the spelling bee, but we hope to continue this winning form on the pitch against Brisbane and Adelaide this week.</p>
+
+<p>This episode is brought to you by the Number 1 (in Asia), the number 10 (in the A-League), and the letter K. </p>
+
+<p>This is Around the Bloc.</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/psub94/S03E09_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:3;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"1d708725dab6731e5c8e88802dd962c1b384ea28cf3300bae48b70d40a3d56cb";s:5:"title";s:39:"S03E8: There are no stupid questions…";s:3:"url";s:71:"http://aroundthebloc.podbean.com/e/s03e8-there-are-no-stupid-questions/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-25 14:26:59.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:923:"The elusive Turner returns for a stint on the podcast that David Villa would be proud of, and with everyone else showing up for once, the team was 6 strong. 6 is also the number of games we’ve played in the A-League without a win, but despite what’s happening up in Brisbane, the Wanderers fans seem to be giving King Popa all their support, which they express in this weeks apparently silly ATBFeedback. The question of the week segment is back also, and is answered by Ivan.
+
+On the bright side, we’re unbeaten in 2, and we cover both the Mariners and Newcastle games, as well as the upcoming Sydney Derby which is a must win for so many reasons - namely the bragging rights that come with it. It could be a first loss for Sydney and a first win for us, or it could potentially see both teams at completely opposite ends of the ladder if things go Sydneys way. Hopefully it’s the former.
+
+This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/npwg6h/S03E08_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:4;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"b2bdefa98e2b7665034a890d634ea41efc01f55a5fad99e857a462c40ec3beaf";s:5:"title";s:18:"S03E07: Min. Power";s:3:"url";s:52:"http://aroundthebloc.podbean.com/e/s03e07-min-power/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-18 12:51:04.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:686:"Well, the Wanderers lost again this week - but given the team line up, is there anything really to worry about? The attitudes of the team and fans alike are positive, but some improvement has to be on the cards.
+
+We found that the podcast needed some improving too, so we introduce Question of the Week on this show, and I give a long, detailed history of podcasting which I’m sure is going to be as much fun for you to listen to as I had telling it, and I didn’t even insult anyone in the process. Well, I don’t think I did - I’ll keep an eye on twitter though. There’s that, W-League, Youth League, Nikminnit and all the other stuff on this weeks episode of Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/5xnk97/S03E07_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:5;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"277f22fc84cbd990b61b1cd1735977db7e7e68ffccfd8b1780f79884266333a4";s:5:"title";s:13:"S03E06: The D";s:3:"url";s:48:"http://aroundthebloc.podbean.com/e/s03e06-the-d/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-11 13:50:22.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:731:"The trilogy has ended and we are Alan-less this week, as well as Ivan-less and Turner-less, not to mention still win-less in the A-league and Santalab-less, because he is shoulder-less. We can’t do much about missing podcasters or the need for surgery, but, like Seyi Adeleke, the Wanderers need to turn around and head in the right direction, and they can begin in Perth where they play the Glory this weekend.
+
+One thing we are not missing this week is Speccy, who has returned from Riyadh to tell us a few tales of the road, and why he thinks Qatar should retain World Cup Hosting rights, and if you haven’t already turned this off to log onto twitter and abuse him for it, thanks for staying tuned - this is Around The Bloc";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/ekpz94/S03E06_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:6;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"bf53dfaace7e3c79364fbccdd436e5e0eabcaf952b682055fd7893dffc9f3976";s:5:"title";s:16:"S03E05: Got It!!";s:3:"url";s:49:"http://aroundthebloc.podbean.com/e/s03e05-got-it/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-04 14:08:17.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:326:"2014 AFC Champions League winners!
+<br/>Special Guest Alan Mtashar returns to complete the trilogy as we discuss the Wanderers’ historic victory in the AFC Champions League Final.
+<br/>There’s pride, tears, food, tangents and plenty of laughs. Pretty much everything you’d expect from another episode of Around The Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/siqdx3/S03E05_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:7;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"1fa34de3fad0a23dc00a3ec3a93afc984d92217f1adcb2c4dbe3d022ca6e5569";s:5:"title";s:29:"S03E04: Lights! Camera! Asia!";s:3:"url";s:61:"http://aroundthebloc.podbean.com/e/s03e04-lights-camera-asia/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-28 13:58:53.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:468:"With the spotlight on us, the crowd roared as we entered the arena and lined up on what was one of the biggest, most nerve wracking nights of our lives. The expectations were huge and the task ahead a gruelling one, but finally, after all the interviews were over, we readied ourselves and… we started recording the most important podcast of our lives. In front of ABC cameras no less.
+
+Oh and the Wanderers are taking a 1-0 lead to Riyadh.
+
+This is Around The Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/j4g9ts/S03E04_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:8;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"66ffaf3284073c2427fd65315713706dac76982bf0b6674c6e12c852a5ec799d";s:5:"title";s:26:"S03E03: Chuckin’ A Tanty";s:3:"url";s:58:"http://aroundthebloc.podbean.com/e/s03e03-chuckin-a-tanty/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-21 13:03:11.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:377:"Another bumper episode of Around the Bloc where we all have our turns at throwing a tantrum over the Derby D’Sydney result and officiating.
+
+Most importantly though, special guest Alan Mtashar provides great insight into the world of Asian football and Al Hilal in particular, as we head towards the 1st leg of the 2014 Asian Champions League Final.
+
+This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/c5e7t3/S03E03_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:9;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"9115b107427d30c99a64ca5abfc252255486062d45231b4c72fae905f244efda";s:5:"title";s:25:"S03E02: Sincerely, Speccy";s:3:"url";s:59:"http://aroundthebloc.podbean.com/e/s03e02-sincerely-speccy/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-14 12:32:20.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:741:"We lost to Melbourne on the weekend. Now, we’re not 1-4 negativity, but it was a pretty poor performance. It was, however, the first time we’ve actually conceded 4 goals but it didn’t seem to bother the 1,500 fans that travelled to see it.
+
+In other news, the W-League team beat Brisbane at Brisbane which is something the A-League squad hasn’t done in a while, and the Youth League squad beat Sydney, which could be a good omen for this weekend’s Derby - the first of the season. The RBB will once again descend (or stumble) upon the SFS in the hopes of taking 3 points home with them in the 8th edition of Popa vs the Smurfs. Will we turn their little village into Gargamel’s lair? Only time will tell.
+
+This is Around the Bloc";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/d294ej/S03E02_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:64:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:10;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"7d1415a98b9df02cbf8fe90007b112af71a62e384417b056abdb24c0556dacb9";s:5:"title";s:40:"S03E01: Two Stars, New Stars, Old Tricks";s:3:"url";s:71:"http://aroundthebloc.podbean.com/e/s03e01-2-stars-new-stars-old-tricks/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-07 13:06:49.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:909:"<p>We’re back for a third season, and hopefully a third star on our logo. It’s been a really successful off season for both the podcast and the team we podcast about - Around the Bloc has won some silverware, but can the Wanderers? Only time will tell as we enter the home stretch of the Asian Champions League campaign, as well as the beginning of another A-League season.</p>
+<p>On the other hand, the FFA Cup was an FFFail, Speccy’s first attempt at<a href="https://www.facebook.com/hashtag/atbbeers?source=feed_text&amp;story_id=376229905861058" rel="noreferrer" target="_blank">‪#‎ATBBeers‬</a> doesn’t quite go to plan, and all those cryptic clues that we put out on twitter that noone even really bothered to mention? Well, you’ll find out about that within the first few minutes of the show.</p>
+
+<p>We promise you, it’s worth a listen. This is the new season of Around the Bloc.</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/i8jpsr/S03E01_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:11;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"42976d5465619da003c95e8009c8d3c151bc79b719e091bce22e308f5c0a26b4";s:5:"title";s:12:"S02E31: ENDS";s:3:"url";s:47:"http://aroundthebloc.podbean.com/e/s02e31-ends/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-05-19 01:22:03.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:819:"That’s it, the end of the 2013-14 season. There were highs, lows, transfers and releases, and still some potential silverware - and thats just for the podcast. The Wanderers had what, in hindsight, was a pretty successful sophomore season and are still in the running for the biggest prize on the continent - the AFC Champions League. 
+<p>Thanks to everyone for listening this year. We’ll return next season with more puns, more laughs, more food talk and more <a href="https://www.facebook.com/hashtag/facts" rel="noreferrer" target="_blank">#facts</a>. Cheers from everyone here at Around the Bloc.</p>
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/sec79f/S02E31_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:12;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"feaf18e49146d1a11d5dd9ecab3dec75e907c4587ae054c3caeec27b3b6bfadc";s:5:"title";s:21:"S02E30: “…….”";s:3:"url";s:42:"http://aroundthebloc.podbean.com/e/s02e30/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-05-07 01:24:31.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:236:"….uuuugggghhhhhhh……
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/sbc8mh/S02E30_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:13;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"1b5be6b5f3283a3e844ec9041a4b8abdb9c7705a659e7efcf3a0eff1ba859cf2";s:5:"title";s:17:"S02E29: Clown Car";s:3:"url";s:52:"http://aroundthebloc.podbean.com/e/s02e29-clown-car/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-30 01:20:12.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1170:"<p>We’re into the final! We’re going to Brisbane! We’re going to see JASON DERULO live! He’s going to say JASON DERULO heaps of times! I personally can’t wait, and the other 4,000 (and counting) Wanderers fans travelling up seem pretty keen as well.</p>
+
+<p>We got our Revenge on the Mariners, but it was anything but a Game of Thrones. We left them for Walking Dead, Breaking Bad through their defence and playing like Mad Men in order to come away with the 2-0 win. Brisbane will be doing their very best to Curb our Enthusiasm, but the Workaholic nature of our play will make it a very tough match. Will the Wanderers Family Guys be strong enough to overcome Berisha, the Total Diva, and his League of Gentlemen? With any luck, come Monday, we’ll all be talking about Roar’s ludicrous display and how they always try to walk it in.</p>
+<p><br/></p>
+
+<p>You’re listening to the It Crowd, AKA Brendan, Steve and Ivan on Around the Bloc.</p>
+
+
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/npjzx2/S02E29_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:14;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"6e4fa13ce5a9a6e64059b09aaebe4771a1fc3b4cb054c2acb2fa6575f24bf14a";s:5:"title";s:35:"S02E28: Big Trouble in Little China";s:3:"url";s:70:"http://aroundthebloc.podbean.com/e/s02e28-big-trouble-in-little-china/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-24 00:05:08.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:991:"<p>2nd in the League, 1st in our group in Asia, 1st in the stands and only a win away from our second consecutive grand final appearance - That’s right, we are almost at the end of the Wanderers worst season on record. The rotation policy, the ‘we’re a squad, not a team’ mentality - it will all hopefully be out the window next year as we play in our second successive ACL campaign.</p>
+
+<p>In more positive news though, we finally got those 5 goals we were looking for against Guizhou, people power prevailed in getting the semi-final kick-off moved to a more football-player-friendly time, and we give you the answer to the question that everyone is asking - is it OK to wear a beret in the RBB?</p>
+<p><br/></p>
+
+<p>Merci pour l’écoute, c’est Autour du Bloc</p>
+
+
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/k8vfnj/S02E28_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:15;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"4d7a9c8f78633759e53ff8da7cc1c569dee7acd1aa2fef3f2deaeda470db1271";s:5:"title";s:31:"S02E27: Who Wears Black Shorts?";s:3:"url";s:65:"http://aroundthebloc.podbean.com/e/s02e27-who-wears-black-shorts/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-16 01:28:54.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:959:"Great Scott! The Wanderers took 3 points away from both Melbourne and Korea this week in two epic performances which had us podcasters travelling through space and time to talk about them, whilst the travelling RBB went for a McFly to either destination, and thankfully nobody had to see a Doc or got involved in any Biff. On the pitch, the team was good enough not to Fox things up, apart from Shinji Ono, who’s number you get if you add Tannen eleven, who had a minor issue with the crossbar.
+<br/>So with the team shoring up 2nd spot in the A-League, and one more round to go in the ACL, we would need some sort of sports almanac to predict what’s going to happen in the coming weeks. You’ll just have to stay tuned to Around the Bloc.
+<br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/5b4fdx/S02E27_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:16;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"50b43fbd9eb1b6a8a3db60e1fc87ae2bf213e3da7ea042c884624a47ea123879";s:5:"title";s:20:"S02E26: Gold Edition";s:3:"url";s:55:"http://aroundthebloc.podbean.com/e/s02e26-gold-edition/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-09 00:25:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:903:"<p>The Wanderers managed a 1-1 draw with the top of the table Brisbane Roar, but it was only an afterthought compared to the farewell given to Tensai by the RBB and the club. The fans chanted, made banners, and clapped along for our man, whilst the club held a pyro party in the sky in true Western Sydney form.</p>
+
+<p>Someone does some ranting this week, although we’re not going to give him any credit for it, and vaccinations affect my ability to pun throughout the intro. Speaking of diseases though, the Yellow Fever podcast is up for a gong at this years FFDU awards, along with the A-League Show and of course, carry-over champs, Around the Bloc - which is starting right now.</p>
+
+
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/wzs7hr/S02E26_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:17;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"7ee45f73d75c53e8742282bde3b77858d697130034305cb8217a3925f29a25ee";s:5:"title";s:23:"S02E25: Twist and Shout";s:3:"url";s:58:"http://aroundthebloc.podbean.com/e/s02e25-twist-and-shout/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-03 01:40:34.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1067:"<p>I get by with a little help from my friend Ivan on this week’s podcast, as Steve is on his way back from the USSR… or Japan, and Turner’s off being a paperback writer or something.</p>
+
+<p>For starters, a huge shout out to the travelling RBB who went on a magical mystery tour to Japan. It made us all proud to see them standing there and we all wished we’d bought a ticket to ride</p>
+
+
+<p>Unfortunately though, it’s been a couple of hard day’s nights for the Wanderers, who are gently weeping after two consecutive losses to late goals, and that has left some fans refusing to give them all their loving. The team won’t be able to buy their love though, so Sgt Popa’s Lonely Hearts Club Band will have to earn it back with a good performance against the Roar on the weekend.</p>
+
+<p>We are the Walrus, and this is Around the Bloc</p>
+
+
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/edwk8g/S02E25_Around_The_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:18;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"4d4ae1939ffffce8cd9279845674445ef36d8e673b1892727cef413fdd512310";s:5:"title";s:22:"S02E24: -title banned-";s:3:"url";s:42:"http://aroundthebloc.podbean.com/e/s02e24/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-26 00:10:32.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1023:"<p>The Premiers Plate is firmly in the hands of the Brisbane Roar, but the Wanderers haven’t left the table just yet, and like a new vegan’s eggs, they’re unbeaten in recent times. The team will have to get their knife and fork into the upcoming fixtures against Mariners and Kawasaki, both of which will be tougher than a $2 steak. Only time will tell if they’re able to repeat history, score early and pork the bus.</p>
+<p>Speaking of pigs, Cop Watch makes an unwanted return this week, as nobody’s scarf, shoes, socks, or 12 year old daughters are safe from the weekly pat-down that Western Sydney’s loyal football fans are subjected to.</p>
+<p>So sit in your allocated seat, refrain from talking or moving - you’re going to listen to this weeks Around the Bloc, whether you like it or not.</p>
+
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/fmhy3u/S02E24_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:19;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"b16174ac1cb7f0351971e09121c32830020b6fdbca84f15e26f217899a48f951";s:5:"title";s:21:"S02E23: Shoot F*rken!";s:3:"url";s:54:"http://aroundthebloc.podbean.com/e/s02e23-shoot-frken/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-18 23:18:15.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:708:"Unlike Mebrahtu, the Wanderers are starting to look strong in the ACL, something I’m sure Golgol won’t find humerus. Ulna-ther news, the team is finding the A-League tough, but maybe they should listen to us when we keep patella-n them to shoot. After all, some goals would’ve been nice as the RBB were going out and they were dancing in the storm, getting soaked to the bone in the process.
+<p>There’s rants galore and much more, so skull your drink and get ready for Around the Bloc.</p>
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/kagis8/S02E23_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:20;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"9ee35d69ce31c9864ce726904626b558e70adf7dc6f775abc576006ee2912537";s:5:"title";s:31:"S02E22: To Sydney, with love…";s:3:"url";s:62:"http://aroundthebloc.podbean.com/e/s02e22-to-sydney-with-love/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-11 22:58:23.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:937:"Sydney FC won the third Sydney Derby of the season thanks to the Wanderers playing like d’apu-zzo they left Allianz Stadium with their tail between their legs, knowing they won’t go top-or close to it for at least another week. The atmosphere was, as the French say, La Rocca’n, and the 40,000 that packed the ground left the NRL journo’s saying ‘Ono!’, just like Meggsy said after that through ball to Garcia. It was a Bridge too far for the Wanderers though, and Santa came early for the Sky Blue side of Sydney.
+<br/>Finally, the Red and Black hoops are off to China to ask ‘Guizhou, where you goin’ with that gun in your hand?’ and then back to play Adelaide at Wanderland.
+<br/>This is Around the Bloc.
+
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/znutb3/S02E22_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:21;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"16517eb672c6227c772d6b75bb18e5f40d6617384419ca252b04b7c152e56cc0";s:5:"title";s:29:"S02E21: La Banda-ing Together";s:3:"url";s:64:"http://aroundthebloc.podbean.com/e/s02e21-la-banda-ing-together/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-05 02:25:30.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1006:"A huge episode this week as two members of the RBB’s band, La Banda, join us to share their opinions on all the on and off the pitch happenings, which they drum into us, and are generally bass’d on their experiences in the RBB. Having been one of the cymbals of the active supporter group since day 1, they try not to repinique themselves as they recall how they formed, how the chants come together, and why they, for some reason, love Tom-Tomi Juric.
+
+Also on the show……………………………………………….. thats right - the silent protest. We delve into the why, the who, what, when, the where and the how, as we were all grabbing our hair and tearing it out wondering what the hell was going on. 
+
+Sit back, relax and drop it like it’s hot - this is Around the Bloc
+
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
+
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/4b9fyv/S02E21_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:22;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"358e2c672c30776704ad37f6205fe90d6e957dc3bea24759e2e05f6a86395eba";s:5:"title";s:19:"S02E20: Dynamic Duo";s:3:"url";s:54:"http://aroundthebloc.podbean.com/e/s02e20-dynamic-duo/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-26 00:01:54.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:787:"And then there were two. With most members of the team missing, the dynamic duo of Steve and Brendan bring you this week’s podcast which is more exciting than a backup goalie’s debut.
+<br/>It was a perfect start to a long run of games for the Wanderers, and with the ACL looming, we turn our attention to the failings of Brisbane Roar and William Gallas. We give credit where credit’s due, though, to everyone’s favourite Wanderers player, Jerrad Tyson (as quoted in The Guardian), and our resident Spanish commentator has something special for him too.
+<br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>
+
+<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/x52pk9/S02E20_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:23;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"a530636c20c2e53edd2103ec481f9b78600c7a59473ab065b313462af25280f1";s:5:"title";s:16:"S02E19: Nameless";s:3:"url";s:51:"http://aroundthebloc.podbean.com/e/s02e19-nameless/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-19 01:22:59.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:722:"<p>With the Wanderers gameless, our podcast could’ve been aimless, if not for some questions which amazed us, sent through by listeners for a talkback segment that’s become famous, for rants and tangents and being totally outrageous and keeping Turner far from blameless. Our plugs are shameless, we hope listening will be painless as we try to offer you something different from the sameness and get to know you on a first name basis, and just like a really fat waitress we are Around the Bloc!
+</p><br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/hvru9y/S02E19_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:24;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"5cc34609174eae2b0c601d64998386f313c90be73957a9a0eb031bafd6770886";s:5:"title";s:16:"S02E18: En-Tyson";s:3:"url";s:51:"http://aroundthebloc.podbean.com/e/s02e18-en-tyson/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-12 01:04:12.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1035:"Everyones favourite Wanderers player, Jerrad Tyson, joins the ATB team for this week, and is a really good sport about getting bombarded with questions until late on a school night. 
+<br/>Berisha makes a nuisance of himself once again, so in the head to head between the Roar and the Wanderers this year, there’s been a 1-1, one team’s won one and one team’s won none. We find out who each podcasters mortal enemy is, Things We Could’ve Done Better Last Week almost makes a comeback, Jerrad offers some insight into the day to day dealings of a Wanderers player and has some handy hints for the relief of Fibromyalgia, whilst Turner, although you can’t hear it, does the exact opposite and polishes off an entire packet of chocolate snacks for the third week running. 
+<br/>This is Around the Bloc.
+
+<br/><p>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/></p><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/miea9s/S02E18_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:64:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:25;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"8cd5bd4644fe619055326755a580d8127a83d44c7dde325b55d858645c64891d";s:5:"title";s:25:"S02E17: Mid-Air Collision";s:3:"url";s:60:"http://aroundthebloc.podbean.com/e/s02e17-mid-air-collision/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-05 01:22:04.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:997:"Unlike the FFA, Around the Bloc does actually appreciate it’s fans, and this week we’ve rectified our premature evacuation of the podcast studio from last week and we’re back to our regular episode length. 
+<br/>The Wanderers went up the Freeway to Newcastle, and after 2 amazing strikes and 2 dubious goals, came away with a point from a 2-all draw. Feeling more blue than a speech from Joel Griffiths, the RBB travelled to the W-League and National Youth League double header in modest numbers and were unfortunate not to see a point from those games. 
+<br/>The foreigners cop it in ATB Feedback this week, the ATB boys are left Mullen over the new signings, such as Antony Golec who is my new Wanderers brother, and Golgol who is Mehbratu.
+<br/>This is Around the Bloc.
+<br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/5cmzh/S02E17_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:26;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"8d5175a9ad7d391f64177552f41726b8018717b57883c0bd641330ff7c2da5ba";s:5:"title";s:28:"S02E16: Ingloryous Wanderers";s:3:"url";s:63:"http://aroundthebloc.podbean.com/e/s02e16-ingloryous-wanderers/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-29 01:45:41.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:771:"<p>Around the Bloc has a new sponsor this week in Cosy Kitchen Catering, but the feast they provided for us wasn’t the only one on offer as the Wanderers devoured Perth Glory in a 3-1 win at Parramatta Stadium. It was the Wanderers thyme to shine as they rocket-ed back into 2nd place, slowly eating away at the top spot. </p>
+<p>ATBFeedback had Speccy all heated up this week, as he struggled to digest some of the answers provided, the Youth league boys had a win but the Roar proved Toum much for the Wanderers ladies up in Queensland. </p>
+<p>You can have your cake and eat it too, on this weeks episode of Around the Bloc. </p>
+<p>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at http://www.facebook.com/CosyKitchenCatering
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/rg46ga/S02E16_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:27;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"f225971b402e0c5bac7000d1520b4fc5846013aaa301f8723d3d3f0c3951d596";s:5:"title";s:24:"S02E15: Prodigal Podcast";s:3:"url";s:59:"http://aroundthebloc.podbean.com/e/s02e15-prodigal-podcast/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-22 00:49:59.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:702:"The Wanderers went to the City of Churches, praying for a win. Popa put a team on the pitch that had some fans asking ‘why have you forsaken me?’. And would you Adam-and-Eve it? We came away with another loss. It was the RBB’s tour of duty though, and the quality of the active support is a testament to the travelling fans. 
+<br/>In other news, Shinji Ono is leaving the club, unlikely to return in 3 days, the W-League and Youth League teams struggle through their matches, although neither are crucified as much as Speccy is when we confront him about his ‘Prodigal Son’ call from last week. 
+<br/>In the name of the Iván, the Turner, the Brendan and Steve, this is Around the Bloc.
+<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/udajt5/S02E15_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:28;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"0af60f8dfd83a91b8721387f3421e63cb20d57655be47a21b1fbc3b858de6714";s:5:"title";s:26:"S02E14: Two and a Half Men";s:3:"url";s:61:"http://aroundthebloc.podbean.com/e/s02e14-two-and-a-half-men/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-16 02:33:42.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:440:"Two and a half men present this week’s podcast, with a lineup more depleted than the Wanderers themselves, bringing you the mixed news from the last week. The Wanderers were the first team to win the Sydney Derby at home, but followed it up with a loss in Melbourne.
+<br/>ATBFeedback goes into overdrive, Speccy and JAR go overboard, transfer rumours are overhyped and we all get overtly stupid, in this week’s overtime Around The Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/hywpi9/S02E14_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:29;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"6c408c42800416b22a33267fea943cf3fa9ab3a6ef83453f0436be3d01ed680d";s:5:"title";s:34:"S02E13: Nightmare on Melbs Streets";s:3:"url";s:69:"http://aroundthebloc.podbean.com/e/s02e13-nightmare-on-melbs-streets/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-08 00:46:26.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:581:"On Around the Bloc this week - Club in crisis, as Wellington are the first team to defeat the Wanderers at Parramatta in almost a year, and have now 1-3 in a row. 
+<br/>The pressing issue this week, though, is the suspended sentences placed on Western Sydney and the Melbourne Victory over the events that took place before and during their last game. The team discuss their views and one ATB member gets all ‘tin-foil-hat’ about it. 
+<br/>We review the upcoming Sydney Derby, offer the worst football tips on the planet, and much more on this edition of Around the Bloc.
+<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/dsye4n/S02E13_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:30;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"47f92bf67ab76489f430d9d2cbc26fbc6c564b90198ef72fd935ae00f3928c06";s:5:"title";s:20:"S02E12: The Hangover";s:3:"url";s:55:"http://aroundthebloc.podbean.com/e/s02e12-the-hangover/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-02 03:05:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:714:"<p>Fireworks, this week, as the ATB boys
+leave their luxurious holiday homes to once again bung on about the Wanderers
+in the first podcast of the new year. We showed sparkle and flare to beat the
+Mariners, were disappointed at what seemed like a minute after midnight in
+Melbourne, and Wellington were 2 hours AND 2 goals ahead of us, although we
+didn’t know that at the time of recording so you can still hear the gleeful
+optimism in our voices.</p>
+<p>#ATBFeedback goes live this week and we
+hear many different stories from Wanderers away trips, straight from the horse’s
+mouths, and all the usual stuff is in there too.</p>
+
+<p>Finally, Happy New Year to all of our
+listeners. This is Around The Bloc.</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/673jx/Around_The_Bloc_podcast_S02E12.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:31;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"d1f0fd26c1fcd19bddc3a514855222547f0282cdad90d69e08f80703f78e37df";s:5:"title";s:22:"S02E11: Three Wise Men";s:3:"url";s:57:"http://aroundthebloc.podbean.com/e/s02e11-three-wise-men/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-12-18 01:37:51.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:619:"The RBB followed their stars up the road for anything but a silent night in Newcastle. On this week’s podcast, three wise men discuss whether Mark Bridge’s goal was the result of a push in the back, or an immaculate deflection off Haliti’s head, if Birighitti should have been told ‘theres no more room at the inn’, and how the little drummer boy broke his instrument. 
+<br/>In other news, Perth do away with their man(a)ger, ATBFeedback turns into a celebratory feast and the W-League team goes on their merry way to record a win against the Glory. All this and more on this weeks edition of Around the Bloc.";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/ccb6x/S02E11_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:32;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"ebc093f2132d1f822e22359645429cc8c090c3558dd10623053d3133864ecc0a";s:5:"title";s:22:"S02E10: Drawn Together";s:3:"url";s:57:"http://aroundthebloc.podbean.com/e/s02e10-drawn-together/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-12-11 01:23:28.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:514:"This week - The Asian Champions League draw is announced, during which the Wanderers will be China win to progress through the group stages and create Korea highlights for themselves, and if they succeed, Japandamonium will ensue. 
+<br/>In the meantime however, the club falls deeper into crisis as they go yet another game without a win and add another draw to their streak. Will they be able to break it against the relentlessness of the Newcastle Jets? 
+<br/>All this and more on this edition of Around the Bloc";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/7gn4p/S02E10_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:33;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"ab8415ae2f421422b1a3063470ff6719e4d3554bd37b624a74ee12a1ab2a330d";s:5:"title";s:24:"S02E09: Club in Crisis!!";s:3:"url";s:57:"http://aroundthebloc.podbean.com/e/s02e09-club-in-crisis/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-12-04 03:22:19.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:583:"<p>It’s episode 9 this week, and that means we’re one third of the way through the season. The Wanderers played a pretty boring nil-all draw on the weekend, and as a result, just like the team we’re playing next week, we all lose our Kewell. Our resident Spanish Commentator makes his return, but with nothing to commentate on we turn our attention to squad rotation and whether or not it’s a good thing. Speaking of going around in circles, the rest of the podcast includes W-League, Youth League, an “International wrap up”, and more. This is Around the Bloc. <br/></p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/g8hhht/S02E09_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:34;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"89cded3f6ce98c6dafceb1fb3c5f6403cc1dc88ca57096137677a4faf00e9d4a";s:5:"title";s:38:"S02E08: Scrappy Curtains with Pancakes";s:3:"url";s:73:"http://aroundthebloc.podbean.com/e/s02e08-scrappy-curtains-with-pancakes/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-27 01:05:32.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:624:"<p>Around the Bloc returns for another week and, like Brisbane Roar, is only good for about 20 minutes, but still does enough to see out a full hour and a half. Turner, our resident caped crusader, tells us what he remembers of his antics from the away trip whilst Brendan makes one too many trips to Marconi. The boys finally get to dissect a loss but, with the help of <a href="https://www.facebook.com/hashtag/atbfeedback" rel="noreferrer" target="_blank">#ATBFeedback</a>, are able to see the positives. There’s good news for the Youth League, segues galore, and much much more on this edition of Around the Bloc.
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/jjv4rf/S02E08_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:35;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"95d652c913366832bd26c6bc9f9d16da762a8a481939afa7c637338b263f1757";s:5:"title";s:27:"S02E07: Reigning at the Top";s:3:"url";s:62:"http://aroundthebloc.podbean.com/e/s02e07-reigning-at-the-top/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-20 00:45:16.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:703:"<p>It was wet, wet, wet in Parramatta on Saturday night, but the love was certainly not all around in the stadium, with the two arguably biggest and most passionate groups of fans in the A-League battling it out in the stands. It was 82 minutes before Mark Bridge put away the winner, and less than 24 hours later the Wanderers finished the round at the top of the table for the first time this season. The bliss turns to diss in ATBFeedback, the joy for the Wanderers unfortunately stopped short of the W-League and Youth League games, and the Newcastle Jets and Michael Turner both pull off upsets over their opponents in the same game. All this and much more on this edition of Around The Bloc. 
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/nnfgj8/S02E07_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:36;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"bfe8d7e67b45fed021accd333968663f9c04862fea60f7877377b7bde770b290";s:5:"title";s:17:"S02E06: Heartbeat";s:3:"url";s:52:"http://aroundthebloc.podbean.com/e/s02e06-heartbeat/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-13 00:15:01.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:714:"On the day Santalab showed his loyalty to the Wanderers like a Golden Lab to a blind man, the ATB boys are back with another episode more chockers than Parramatta Stadium will be on Saturday night. After a gritty 1-0 win where Cole scored in the cold, TomiGun should’ve kept the safety on and the team had the Heart beat, we look forward to victory over the Victory both on and off the pitch. Cop Watch returns in comical fashion, we report on the start of the W-League and the women and youth teams double header, which was the second one of the weekend after Seb Ryall’s goal from the Big Blue. All this and much more on this edition of Around The Bloc. 
+<br/>Oh…and we interview Foxsport’s Adam Peacock.";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/w4vw3/S02E06_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:37;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"5009b50603a446b32272bec2dd4b0d9526797253818d3a47b4252ed7a9975780";s:5:"title";s:38:"S02E05: Receipt, Deceit, but no Defeat";s:3:"url";s:71:"http://aroundthebloc.podbean.com/e/s02e05-receipt-deceit-but-no-defeat/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-06 03:43:33.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:639:"<p>With Speccy benched, ATB is down to 4 men this week. TomiGun© put 2 away at home against the Reds whilst Polenz was lucky that only Adelaide’s secondary kit colour featured amongst the cards shown to him on Friday night. Cop Watch is back, unfortunately, due to fear of a receipt roll planet, and ATBTalkback reveals the pep talks that Wanderers fans would use to pump up the team. Finally, the W-League returns with a double header featuring the WanderWomen and the WanderKids of the National Youth League at Marconi, and the ATB tipping comp receives a shake up. All this and more, on this week’s edition of Around the Bloc.
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/cxfuam/S02E05_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:38;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"7b2fad97ff41c9b417d947c5148fcc0bb244f4421500dc97fcb9429a2476d6ab";s:5:"title";s:41:"S02E04: A better love story than Twilight";s:3:"url";s:76:"http://aroundthebloc.podbean.com/e/s02e04-a-better-love-story-than-twilight/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-30 01:04:54.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:683:"<p>Around the Bloc has a special announcement - this week, we talk about football! The beautiful game is back in the spotlight as the Wanderers defeat Sydney FC in the first Derby D’Sydney of the season. Speccy turned up, Brendan was there too but… also kind of wasn’t, Ivan revelled in the cool, fresh air (for most of the night), Turner made the papers again and Stephen got to make fun of everyone for all of the above. Aside from a few exceptions, the Police and media were generally well-behaved.<br/>We find out what rituals different Wanderers fans have pre-game in ATBTalkback and preview our first game to be aired live, on free-to-air TV against Adelaide United.
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/wjeiq5/S02E04_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:39;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"dc933486dcb16368f6cb66f2f4d0dcb8a437ba6ad216b40454edcf7cf2c9ab92";s:5:"title";s:32:"S02E03: To the left, to the left";s:3:"url";s:66:"http://aroundthebloc.podbean.com/e/s02e03-to-the-left-to-the-left/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-23 00:36:44.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:686:"<p>Football is, for once, the minor topic on this week’s podcast, as we are unfortunately forced to turn our attention to towards the over handed approach the authorities are taking towards Western Sydney’s football fans. Ivan interviews Chadi (a Defence Attorney), Danielle (whose relatives were victims of these tactics), and none other than Lyall Gorman, Wanderers CEO, to get their opinions on what is fast becoming the biggest issue we are facing when supporting our sport.</p>
+<p>On a lighter note, we DO actually talk about football, with the 1-1 against Wellington last week, and the Derby D’Sydney coming up, and Nick Nova’s ‘Do You Even Dale?’ makes its debut.</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/vqtbpc/S02E03_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:40;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"a6a23d90ea8c5165a8029d9aa86dec6285c68000bbf43c3d5db0483fafd48571";s:5:"title";s:19:"S02E02: Say Cheese!";s:3:"url";s:53:"http://aroundthebloc.podbean.com/e/s02e02-say-cheese/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-16 01:19:39.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:310:"<p>The team get together this week and discuss issues such as the RBB becoming the new stars of ‘Australia’s funniest home surveillance videos’, all the news from the latest Wanderers fan forum, a preview of our first home game of the season and much more, on this edition of Around the Bloc…</p>
+<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/ncxtdb/S02E02_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:41;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"3a1608c23c152ba35d07ea731117aa0595037b863dce10e73c0b8f63204f889a";s:5:"title";s:35:"S02E01: The Difficult Second Season";s:3:"url";s:70:"http://aroundthebloc.podbean.com/e/s02e01-the-difficult-second-season/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-09 05:23:27.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:379:"<p>The Around the Bloc team take our seats once more for another exciting year of banter as we attempt to defend our Podcast D’Or award.</p>
+<p>On this weeks episode we talk A-League, W-League, Youth League and Powerchair League, get an update on those schnitzel rolls from Campbelltown Stadium, discuss the ins, outs, ups and downs of the off season and much much more… </p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/hjuu3c/S02E01_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+				
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:42;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"400c94b0f101c91f83d45b38af45b6289d36a02a5f8ea36c29ccf82a42a00b9a";s:5:"title";s:31:"Episode 24: Grand Final relapse";s:3:"url";s:66:"http://aroundthebloc.podbean.com/e/episode-24-grand-final-relapse/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-25 08:54:57.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:616:"<p>In the season finale JAR, Speccy, Turner &amp; Erebus grieve together over the grand final loss but fondly look back at the Wanderers’ very successful first season. We discuss season highlights in #ATBTalkback and recap the parade in Parramatta and the WSW awards night. Thanks to all our listeners and contributors over the season and we’ll be back next season bigger and better! Check us out on twitter - <a href="http://twitter.com/ATBWSW" rel="noreferrer" target="_blank">@ATBWSW</a> - or <a href="http://www.facebook.com/AroundTheBloc" rel="noreferrer" target="_blank">facebook.com/AroundTheBloc</a>
+</p>";s:13:"enclosure_url";s:80:"http://aroundthebloc.podbean.com/mf/feed/z5umt/Around_the_Bloc_podcast_ep024.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:43;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"039cdc6ba289e62ff83bbe7becd07a37dc0913d05335b76938040968217e8bd7";s:5:"title";s:32:"Episode 23: Stadium Wide Pozcast";s:3:"url";s:67:"http://aroundthebloc.podbean.com/e/episode-23-stadium-wide-pozcast/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-18 02:27:18.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:331:"<p>JAR, Speccy, Turner &amp; Erebus talk about two of the most important games in our clubs history - the Semi Final against Brisbane Roar, and the impending Grand Final against Central Coast Mariners. #ATBTalkback returns and actually kind of works this time. Check us out on twitter - @ATBWSW - or facebook.com/AroundTheBloc
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/5u3u83/Around_the_bloc_podcast_ep023.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:44;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"58b057fab6eb2f643ef9d5962d1c42961a97001ffa27c5f18446d3cde920aaa4";s:5:"title";s:53:"Episode 22: Wait a minute? You Guys didn’t play?!?!";s:3:"url";s:80:"http://aroundthebloc.podbean.com/e/episode-22-wait-a-minute-you-guys-didnt-play/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-11 01:18:29.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:637:"<p>FFDU Nominated Finalist; Around the Bloc are joined by Erebus, JAR, Turner &amp; Speccy as they smash through a quick episode (for our standards) discussing the sudden death finals that have happened over the weekend, the upcoming semi final against Brisbane which has got everyone talking! Listen in for details regarding the march, our predictions, Speccy finally winning ‘guess a player’ segment to bring Erebus’ winning streak to an end and our resident Latin correspondent; Pistola giving us an indepth interview! Follow us on twitter ‘@ATBWSW’, like us on Facebook; ‘Around the Bloc’ and subscribe via iTunes!
+</p>";s:13:"enclosure_url";s:80:"http://aroundthebloc.podbean.com/mf/feed/n3dme/Around_the_bloc_podcast_ep022.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:45;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"371ae51388bc263cf23a0f85d646e62f9b46c08762272a35af26d8781a9e358f";s:5:"title";s:46:"Episode 21: Campeone, Campeone, Ole, Ole, Ole!";s:3:"url";s:76:"http://aroundthebloc.podbean.com/e/episode-21-campeone-campeone-ole-ole-ole/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-04 03:27:32.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:677:"<p>Speccy returns and joins JAR, Erebus and a slightly inebriated Turner to discuss and celebrate the Wanderers winning the premiership in their first year as a football club. The release date of this podcast, April 4th, 2013, also happens to be the Wanderers first birthday (i.e. 1 year since the PM announced that it would be happening). A lot has happened since then, but despite the length of the podcast, not all of it is discussed as we stick to the most important parts of the last week. The team recorded on the day of the Newcastle game and that audio is included too. Also: ATB Talkback, Spanish Commentary from Pistola and more. Check us out on twitter @ATBWSW.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/ypjrdm/Around_the_bloc_podcast_ep021.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:46;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"078fb324759d5bbc9ca5db3f2323fa13ee25909ebabaaabc2901fa8d78a4d0ea";s:5:"title";s:21:"Episode 20: Milestone";s:3:"url";s:56:"http://aroundthebloc.podbean.com/e/episode-20-milestone/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-28 01:41:45.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:650:"<p>In the absence of Speccy once again, JAR, Erebus and Turner discuss football, and realise they are the only ‘media’ outlet in Sydney doing so this week. The actual match that was played between the Wanderers and Sydney FC is discussed, as opposed to off-field incident’s which everyone is sick of hearing about, along with everyones chances of making the finals (which admittedly gets a bit confusing), the transport and the RBBQ before the last regular season game in Newcastle, and turners infamous ‘Who Am I?’ segment gets another run. TWCDBLW possibly meets it’s untimely demise too. Check out www.twitter.com/ATBWSW for more.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/x2bb3k/Around_the_bloc_podcast_ep020.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:47;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"84a919d97cd1f33ae8357fd99ace2c8ab2d7fe9101536f2d94ced27b797cb0a7";s:5:"title";s:38:"Episode 19: And Then There Were Two…";s:3:"url";s:70:"http://aroundthebloc.podbean.com/e/episode-19-and-then-there-were-two/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-21 03:52:37.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:458:"<p>JAR and Turner are left to their own devices by an absent Speccy and Erebus and quite frankly, they control the ship just nicely. The dynamic duo cut a boosegump inducing promo for the upcoming derby, discuss the Heart game and the infamous ‘incident’ that occurred. Dicko has his say about that too. Details for the FFDU awards, the Newcastle RBBBBBQB and #ATBTalkback also feature in this episode. Check out www.westsydneyfootball.com for more.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/w8qsxz/Around_the_bloc_podcast_ep019.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:64:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+		
+		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:48;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"0c58ecb9d07513d17fdfcdfb596507bc7aaa35186bee19f534cb12b3e94dccd5";s:5:"title";s:52:"Episode 18: Seriously this time… Back to our Roots";s:3:"url";s:84:"http://aroundthebloc.podbean.com/e/episode-18-seriously-this-time-back-to-our-roots/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-14 05:30:11.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:359:"<p>JAR, Speccy, Turner and Erebus grab the constructive criticism received through the week by the horns and go back to what they do best. The infamous silent protest is covered along with the game against Wellington, the upcoming game against Heart, the tickets given to underprivileged kids and much more. Check out www.westsydneyfootball.com for more.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/4thrnf/Around_the_bloc_podcast_ep018.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:49;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"04394c9ec5c3e540e4050ab9ec295165ab182541074e2c0eb33aafc6d6db6a8b";s:5:"title";s:34:"Episode 17: Live From the JERRcave";s:3:"url";s:69:"http://aroundthebloc.podbean.com/e/episode-17-live-from-the-jerrcave/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-07 04:57:39.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:700:"<p>JAR, Speccy, Turner and Erebus rock up to Jerrad, Joey and Tahj’s pad for a game of UNO and a podcast ensues. The Wanderers winning against Mariners and going top of the league, the upcoming game against Wellington, an ‘in-the-making’ documentary about the Wanderers and the RBB and the recent charity work that has seen some underprivileged community groups receive tickets to the Nix game are all discussed. As it stands, JJ &amp; T are up 2-0 in the FIFA 13 stakes, comfortably defeating the team of JAR and two blokes who don’t know how to play FIFA in two games. Follow us on twitter @ABTWSF or www.facebook.com/aroundthebloc . Also check out www.westsydneyfootball.com for more.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/tynye6/Around_the_bloc_podcast_ep017.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+		
+		
+		
+		
+		
+		
+	
+		
+		
+			
+			
+			
+				
+		
+		
+		
+		
+		
+				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}}s:2:"id";s:33:"http://aroundthebloc.podbean.com/";s:5:"title";s:15:"Around the Bloc";s:11:"description";s:169:"The Official Supporters Podcast of the Western Sydney Wanderers. www.aroundthebloc.com.au Now on iTunes - https://itunes.apple.com/au/podcast/around-the-bloc/id581817326";s:8:"feed_url";s:0:"";s:8:"site_url";s:33:"http://aroundthebloc.podbean.com/";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-16 12:56:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:8:"language";s:2:"en";s:4:"logo";s:72:"http://imglogo.podbean.com/image-logo/586645/ATBLogo-BlackBackground.png";s:4:"icon";s:0:"";}

--- a/tests/fixtures/podbean.xml.serialized
+++ b/tests/fixtures/podbean.xml.serialized
@@ -2,297 +2,438 @@ O:20:"PicoFeed\Parser\Feed":10:{s:5:"items";a:50:{i:0;O:20:"PicoFeed\Parser\Item
 
 With mostly away games coming up, we’ve got details of how the RBB will be getting behind Nato - flag making and waving extraordinaire - who’s having a rough time, as well as all the usual stuff as well.
 
-This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/xb5pjd/S03E11_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/xb5pjd/S03E11_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3243:"<item>
+		<title>S03E11: Finding Nemo-rocco</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e11-finding-nemo-rocco/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e11-finding-nemo-rocco/#comments</comments>
+		<pubDate>Tue, 16 Dec 2014 12:56:02 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:1;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"086b4e30d607581a998514246ca35e348d3650796b6cea93a5313602893ee02b";s:5:"title";s:32:"S03E10: No Money, Mo’ Problems";s:3:"url";s:63:"http://aroundthebloc.podbean.com/e/s03e10-no-money-mo-problems/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-09 13:20:39.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:490:"Well, the Wanderers lost two games in the last week, and to top it off, the players are having issues with the clubs owners about their bonuses for playing in the Club World Cup… That’s right, the Wanderers are playing in the Club World Cup! We start off against a Mexican team, once we Cruz through them, things will get Real… really Real. After we Bale them over, we’ve got one game to win before we’re champions of the world.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e11-finding-nemo-rocco/</guid>
+		<description><![CDATA[<div>The Wanderers this week played in the club world cup, where they came off the pitch squeaky clean due to the weather, but couldn’t keep their sheet in the same condition and missed out on their dream match with Real Madrid. The team now goes on to contest the fifth place playoff against Algerian team ES Setif, who we hope gets ES se-mashed.</div>
+<div></div>
+<div>With mostly away games coming up, we’ve got details of how the RBB will be getting behind Nato - flag making and waving extraordinaire - who’s having a rough time, as well as all the usual stuff as well.</div>
+<div></div>
+<div>This is Around the Bloc.</div>
+]]></description>
+			<content:encoded><![CDATA[<div>The Wanderers this week played in the club world cup, where they came off the pitch squeaky clean due to the weather, but couldn’t keep their sheet in the same condition and missed out on their dream match with Real Madrid. The team now goes on to contest the fifth place playoff against Algerian team ES Setif, who we hope gets ES se-mashed.</div>
+<div></div>
+<div>With mostly away games coming up, we’ve got details of how the RBB will be getting behind Nato - flag making and waving extraordinaire - who’s having a rough time, as well as all the usual stuff as well.</div>
+<div></div>
+<div>This is Around the Bloc.</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e11-finding-nemo-rocco/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/xb5pjd/S03E11_Around_the_Bloc_podcast.mp3" length="46318627" type="audio/mpeg"/>
+				<itunes:subtitle>The Wanderers this week played in the club world cup, where they came off the pitch squeaky clean due to the weather, but couldn't keep ...</itunes:subtitle>
+		<itunes:summary>The Wanderers this week played in the club world cup, where they came off the pitch squeaky clean due to the weather, but couldn't keep their sheet in the same condition and missed out on their dream match with Real Madrid. The team now goes on to contest the fifth place playoff against Algerian team ES Setif, who we hope gets ES se-mashed.With mostly away games coming up, we’ve got details of how the RBB will be getting behind Nato - flag making and waving extraordinaire - who’s having a rough time, as well as all the usual stuff as well.This is Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:50:05</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E11: Finding Nemo-rocco</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:1;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"086b4e30d607581a998514246ca35e348d3650796b6cea93a5313602893ee02b";s:5:"title";s:32:"S03E10: No Money, Mo’ Problems";s:3:"url";s:63:"http://aroundthebloc.podbean.com/e/s03e10-no-money-mo-problems/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-09 13:20:39.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:490:"Well, the Wanderers lost two games in the last week, and to top it off, the players are having issues with the clubs owners about their bonuses for playing in the Club World Cup… That’s right, the Wanderers are playing in the Club World Cup! We start off against a Mexican team, once we Cruz through them, things will get Real… really Real. After we Bale them over, we’ve got one game to win before we’re champions of the world.
 
 Easier said than won eh?
 
-This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/h6ifqz/S03E10_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/h6ifqz/S03E10_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:2990:"<item>
+		<title>S03E10: No Money, Mo’ Problems</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e10-no-money-mo-problems/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e10-no-money-mo-problems/#comments</comments>
+		<pubDate>Tue, 09 Dec 2014 13:20:39 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:2;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"c513e75f5e4722eb556fc72dac3bb88fd27e9a3e20be5591819d57f2b026af04";s:5:"title";s:14:"S03E09: K-Gate";s:3:"url";s:49:"http://aroundthebloc.podbean.com/e/s03e09-k-gate/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-02 13:47:31.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:629:"<p>The second derby of the season has come and gone, and the Cove and the RBB were both fans of the team that didn’t win. Tomi Gun’s goal was cancelled out by a screamer from Ibini, and the Wanderers winless and undefeated streaks continue.</p>
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e10-no-money-mo-problems/</guid>
+		<description><![CDATA[<div>Well, the Wanderers lost two games in the last week, and to top it off, the players are having issues with the clubs owners about their bonuses for playing in the Club World Cup… That’s right, the Wanderers are playing in the Club World Cup! We start off against a Mexican team, once we Cruz through them, things will get Real… really Real. After we Bale them over, we’ve got one game to win before we’re champions of the world.</div>
+<div></div>
+<div>Easier said than won eh?</div>
+<div></div>
+<div>This is Around the Bloc.</div>
+]]></description>
+			<content:encoded><![CDATA[<div>Well, the Wanderers lost two games in the last week, and to top it off, the players are having issues with the clubs owners about their bonuses for playing in the Club World Cup… That’s right, the Wanderers are playing in the Club World Cup! We start off against a Mexican team, once we Cruz through them, things will get Real… really Real. After we Bale them over, we’ve got one game to win before we’re champions of the world.</div>
+<div></div>
+<div>Easier said than won eh?</div>
+<div></div>
+<div>This is Around the Bloc.</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e10-no-money-mo-problems/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/h6ifqz/S03E10_Around_the_Bloc_podcast.mp3" length="70387085" type="audio/mpeg"/>
+				<itunes:subtitle>Well, the Wanderers lost two games in the last week, and to top it off, the players are having issues with the clubs owners about ...</itunes:subtitle>
+		<itunes:summary>Well, the Wanderers lost two games in the last week, and to top it off, the players are having issues with the clubs owners about their bonuses for playing in the Club World Cup… That’s right, the Wanderers are playing in the Club World Cup! We start off against a Mexican team, once we Cruz through them, things will get Real… really Real. After we Bale them over, we've got one game to win before we’re champions of the world.Easier said than won eh?This is Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:47:25</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E10: No Money, Mo’ Problems</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:2;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"c513e75f5e4722eb556fc72dac3bb88fd27e9a3e20be5591819d57f2b026af04";s:5:"title";s:14:"S03E09: K-Gate";s:3:"url";s:49:"http://aroundthebloc.podbean.com/e/s03e09-k-gate/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-02 13:47:31.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:629:"<p>The second derby of the season has come and gone, and the Cove and the RBB were both fans of the team that didn’t win. Tomi Gun’s goal was cancelled out by a screamer from Ibini, and the Wanderers winless and undefeated streaks continue.</p>
 
 <p>The club did, however, perform well at the AFC Awards night, winning Club and Coach of the Year. We lost in the spelling bee, but we hope to continue this winning form on the pitch against Brisbane and Adelaide this week.</p>
 
 <p>This episode is brought to you by the Number 1 (in Asia), the number 10 (in the A-League), and the letter K. </p>
 
-<p>This is Around the Bloc.</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/psub94/S03E09_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<p>This is Around the Bloc.</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/psub94/S03E09_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3599:"<item>
+		<title>S03E09: K-Gate</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e09-k-gate/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e09-k-gate/#comments</comments>
+		<pubDate>Tue, 02 Dec 2014 13:47:31 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:3;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"1d708725dab6731e5c8e88802dd962c1b384ea28cf3300bae48b70d40a3d56cb";s:5:"title";s:39:"S03E8: There are no stupid questions…";s:3:"url";s:71:"http://aroundthebloc.podbean.com/e/s03e8-there-are-no-stupid-questions/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-25 14:26:59.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:923:"The elusive Turner returns for a stint on the podcast that David Villa would be proud of, and with everyone else showing up for once, the team was 6 strong. 6 is also the number of games we’ve played in the A-League without a win, but despite what’s happening up in Brisbane, the Wanderers fans seem to be giving King Popa all their support, which they express in this weeks apparently silly ATBFeedback. The question of the week segment is back also, and is answered by Ivan.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e09-k-gate/</guid>
+		<description><![CDATA[<p style="margin:0px 0px 6px;">The second derby of the season has come and gone, and the Cove and the RBB were both fans of the team that didn’t win. Tomi Gun’s goal was cancelled out by a screamer from Ibini, and the Wanderers winless and undefeated streaks continue.</p>
+<p style="margin:0px 0px 6px;"></p>
+<p style="margin:6px 0px;">The club did, however, perform well at the AFC Awards night, winning Club and Coach of the Year. We lost in the spelling bee, but we hope to continue this winning form on the pitch against Brisbane and Adelaide this week.</p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">This episode is brought to you by the Number 1 (in Asia), the number 10 (in the A-League), and the letter K. </p>
+<p style="margin:0px 0px 6px;"></p>
+<p style="margin:0px 0px 6px;">This is Around the Bloc.</p>
+</div>
+]]></description>
+			<content:encoded><![CDATA[<p style="margin:0px 0px 6px;">The second derby of the season has come and gone, and the Cove and the RBB were both fans of the team that didn’t win. Tomi Gun’s goal was cancelled out by a screamer from Ibini, and the Wanderers winless and undefeated streaks continue.</p>
+<p style="margin:0px 0px 6px;"></p>
+<p style="margin:6px 0px;">The club did, however, perform well at the AFC Awards night, winning Club and Coach of the Year. We lost in the spelling bee, but we hope to continue this winning form on the pitch against Brisbane and Adelaide this week.</p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">This episode is brought to you by the Number 1 (in Asia), the number 10 (in the A-League), and the letter K. </p>
+<p style="margin:0px 0px 6px;"></p>
+<p style="margin:0px 0px 6px;">This is Around the Bloc.</p>
+</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e09-k-gate/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/psub94/S03E09_Around_the_Bloc_podcast.mp3" length="62410809" type="audio/mpeg"/>
+				<itunes:subtitle>The second derby of the season has come and gone, and the Cove and the RBB were both fans of the team that didn't win. ...</itunes:subtitle>
+		<itunes:summary>The second derby of the season has come and gone, and the Cove and the RBB were both fans of the team that didn't win. Tomi Gun’s goal was cancelled out by a screamer from Ibini, and the Wanderers winless and undefeated streaks continue.The club did, however, perform well at the AFC Awards night, winning Club and Coach of the Year. We lost in the spelling bee, but we hope to continue this winning form on the pitch against Brisbane and Adelaide this week.This episode is brought to you by the Number 1 (in Asia), the number 10 (in the A-League), and the letter K. This is Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:28:27</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E09: K-Gate</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:3;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"1d708725dab6731e5c8e88802dd962c1b384ea28cf3300bae48b70d40a3d56cb";s:5:"title";s:39:"S03E8: There are no stupid questions…";s:3:"url";s:71:"http://aroundthebloc.podbean.com/e/s03e8-there-are-no-stupid-questions/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-25 14:26:59.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:923:"The elusive Turner returns for a stint on the podcast that David Villa would be proud of, and with everyone else showing up for once, the team was 6 strong. 6 is also the number of games we’ve played in the A-League without a win, but despite what’s happening up in Brisbane, the Wanderers fans seem to be giving King Popa all their support, which they express in this weeks apparently silly ATBFeedback. The question of the week segment is back also, and is answered by Ivan.
 
 On the bright side, we’re unbeaten in 2, and we cover both the Mariners and Newcastle games, as well as the upcoming Sydney Derby which is a must win for so many reasons - namely the bragging rights that come with it. It could be a first loss for Sydney and a first win for us, or it could potentially see both teams at completely opposite ends of the ladder if things go Sydneys way. Hopefully it’s the former.
 
-This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/npwg6h/S03E08_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/npwg6h/S03E08_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4341:"<item>
+		<title>S03E8: There are no stupid questions…</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e8-there-are-no-stupid-questions/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e8-there-are-no-stupid-questions/#comments</comments>
+		<pubDate>Tue, 25 Nov 2014 14:26:59 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:4;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"b2bdefa98e2b7665034a890d634ea41efc01f55a5fad99e857a462c40ec3beaf";s:5:"title";s:18:"S03E07: Min. Power";s:3:"url";s:52:"http://aroundthebloc.podbean.com/e/s03e07-min-power/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-18 12:51:04.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:686:"Well, the Wanderers lost again this week - but given the team line up, is there anything really to worry about? The attitudes of the team and fans alike are positive, but some improvement has to be on the cards.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e8-there-are-no-stupid-questions/</guid>
+		<description><![CDATA[<div>The elusive Turner returns for a stint on the podcast that David Villa would be proud of, and with everyone else showing up for once, the team was 6 strong. 6 is also the number of games we’ve played in the A-League without a win, but despite what’s happening up in Brisbane, the Wanderers fans seem to be giving King Popa all their support, which they express in this weeks apparently silly ATBFeedback. The question of the week segment is back also, and is answered by Ivan.</div>
+<div></div>
+<div>On the bright side, we’re unbeaten in 2, and we cover both the Mariners and Newcastle games, as well as the upcoming Sydney Derby which is a must win for so many reasons - namely the bragging rights that come with it. It could be a first loss for Sydney and a first win for us, or it could potentially see both teams at completely opposite ends of the ladder if things go Sydneys way. Hopefully it’s the former.</div>
+<div></div>
+<div>This is Around the Bloc.</div>
+]]></description>
+			<content:encoded><![CDATA[<div>The elusive Turner returns for a stint on the podcast that David Villa would be proud of, and with everyone else showing up for once, the team was 6 strong. 6 is also the number of games we’ve played in the A-League without a win, but despite what’s happening up in Brisbane, the Wanderers fans seem to be giving King Popa all their support, which they express in this weeks apparently silly ATBFeedback. The question of the week segment is back also, and is answered by Ivan.</div>
+<div></div>
+<div>On the bright side, we’re unbeaten in 2, and we cover both the Mariners and Newcastle games, as well as the upcoming Sydney Derby which is a must win for so many reasons - namely the bragging rights that come with it. It could be a first loss for Sydney and a first win for us, or it could potentially see both teams at completely opposite ends of the ladder if things go Sydneys way. Hopefully it’s the former.</div>
+<div></div>
+<div>This is Around the Bloc.</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e8-there-are-no-stupid-questions/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/npwg6h/S03E08_Around_the_Bloc_podcast.mp3" length="67865155" type="audio/mpeg"/>
+				<itunes:subtitle>The elusive Turner returns for a stint on the podcast that David Villa would be proud of, and with everyone else showing up for once, ...</itunes:subtitle>
+		<itunes:summary>The elusive Turner returns for a stint on the podcast that David Villa would be proud of, and with everyone else showing up for once, the team was 6 strong. 6 is also the number of games we’ve played in the A-League without a win, but despite what’s happening up in Brisbane, the Wanderers fans seem to be giving King Popa all their support, which they express in this weeks apparently silly ATBFeedback. The question of the week segment is back also, and is answered by Ivan.On the bright side, we’re unbeaten in 2, and we cover both the Mariners and Newcastle games, as well as the upcoming Sydney Derby which is a must win for so many reasons - namely the bragging rights that come with it. It could be a first loss for Sydney and a first win for us, or it could potentially see both teams at completely opposite ends of the ladder if things go Sydneys way. Hopefully it’s the former.This is Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:21:16</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E8: There are no stupid questions…</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:4;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"b2bdefa98e2b7665034a890d634ea41efc01f55a5fad99e857a462c40ec3beaf";s:5:"title";s:18:"S03E07: Min. Power";s:3:"url";s:52:"http://aroundthebloc.podbean.com/e/s03e07-min-power/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-18 12:51:04.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:686:"Well, the Wanderers lost again this week - but given the team line up, is there anything really to worry about? The attitudes of the team and fans alike are positive, but some improvement has to be on the cards.
 
-We found that the podcast needed some improving too, so we introduce Question of the Week on this show, and I give a long, detailed history of podcasting which I’m sure is going to be as much fun for you to listen to as I had telling it, and I didn’t even insult anyone in the process. Well, I don’t think I did - I’ll keep an eye on twitter though. There’s that, W-League, Youth League, Nikminnit and all the other stuff on this weeks episode of Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/5xnk97/S03E07_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+We found that the podcast needed some improving too, so we introduce Question of the Week on this show, and I give a long, detailed history of podcasting which I’m sure is going to be as much fun for you to listen to as I had telling it, and I didn’t even insult anyone in the process. Well, I don’t think I did - I’ll keep an eye on twitter though. There’s that, W-League, Youth League, Nikminnit and all the other stuff on this weeks episode of Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/5xnk97/S03E07_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3465:"<item>
+		<title>S03E07: Min. Power</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e07-min-power/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e07-min-power/#comments</comments>
+		<pubDate>Tue, 18 Nov 2014 12:51:04 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:5;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"277f22fc84cbd990b61b1cd1735977db7e7e68ffccfd8b1780f79884266333a4";s:5:"title";s:13:"S03E06: The D";s:3:"url";s:48:"http://aroundthebloc.podbean.com/e/s03e06-the-d/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-11 13:50:22.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:731:"The trilogy has ended and we are Alan-less this week, as well as Ivan-less and Turner-less, not to mention still win-less in the A-league and Santalab-less, because he is shoulder-less. We can’t do much about missing podcasters or the need for surgery, but, like Seyi Adeleke, the Wanderers need to turn around and head in the right direction, and they can begin in Perth where they play the Glory this weekend.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e07-min-power/</guid>
+		<description><![CDATA[<div>Well, the Wanderers lost again this week - but given the team line up, is there anything really to worry about? The attitudes of the team and fans alike are positive, but some improvement has to be on the cards.</div>
+<div></div>
+<div>We found that the podcast needed some improving too, so we introduce Question of the Week on this show, and I give a long, detailed history of podcasting which I’m sure is going to be as much fun for you to listen to as I had telling it, and I didn’t even insult anyone in the process. Well, I don’t think I did - I’ll keep an eye on twitter though. There’s that, W-League, Youth League, Nikminnit and all the other stuff on this weeks episode of Around the Bloc.</div>
+]]></description>
+			<content:encoded><![CDATA[<div>Well, the Wanderers lost again this week - but given the team line up, is there anything really to worry about? The attitudes of the team and fans alike are positive, but some improvement has to be on the cards.</div>
+<div></div>
+<div>We found that the podcast needed some improving too, so we introduce Question of the Week on this show, and I give a long, detailed history of podcasting which I’m sure is going to be as much fun for you to listen to as I had telling it, and I didn’t even insult anyone in the process. Well, I don’t think I did - I’ll keep an eye on twitter though. There’s that, W-League, Youth League, Nikminnit and all the other stuff on this weeks episode of Around the Bloc.</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e07-min-power/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/5xnk97/S03E07_Around_the_Bloc_podcast.mp3" length="46842633" type="audio/mpeg"/>
+				<itunes:subtitle>Well, the Wanderers lost again this week - but given the team line up, is there anything really to worry about? The attitudes of the ...</itunes:subtitle>
+		<itunes:summary>Well, the Wanderers lost again this week - but given the team line up, is there anything really to worry about? The attitudes of the team and fans alike are positive, but some improvement has to be on the cards.We found that the podcast needed some improving too, so we introduce Question of the Week on this show, and I give a long, detailed history of podcasting which I’m sure is going to be as much fun for you to listen to as I had telling it, and I didn't even insult anyone in the process. Well, I don’t think I did - I'll keep an eye on twitter though. There’s that, W-League, Youth League, Nikminnit and all the other stuff on this weeks episode of Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:37:30</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E07: Min. Power</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:5;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"277f22fc84cbd990b61b1cd1735977db7e7e68ffccfd8b1780f79884266333a4";s:5:"title";s:13:"S03E06: The D";s:3:"url";s:48:"http://aroundthebloc.podbean.com/e/s03e06-the-d/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-11 13:50:22.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:731:"The trilogy has ended and we are Alan-less this week, as well as Ivan-less and Turner-less, not to mention still win-less in the A-league and Santalab-less, because he is shoulder-less. We can’t do much about missing podcasters or the need for surgery, but, like Seyi Adeleke, the Wanderers need to turn around and head in the right direction, and they can begin in Perth where they play the Glory this weekend.
 
-One thing we are not missing this week is Speccy, who has returned from Riyadh to tell us a few tales of the road, and why he thinks Qatar should retain World Cup Hosting rights, and if you haven’t already turned this off to log onto twitter and abuse him for it, thanks for staying tuned - this is Around The Bloc";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/ekpz94/S03E06_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+One thing we are not missing this week is Speccy, who has returned from Riyadh to tell us a few tales of the road, and why he thinks Qatar should retain World Cup Hosting rights, and if you haven’t already turned this off to log onto twitter and abuse him for it, thanks for staying tuned - this is Around The Bloc";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/ekpz94/S03E06_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3861:"<item>
+		<title>S03E06: The D</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e06-the-d/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e06-the-d/#comments</comments>
+		<pubDate>Tue, 11 Nov 2014 13:50:22 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:6;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"bf53dfaace7e3c79364fbccdd436e5e0eabcaf952b682055fd7893dffc9f3976";s:5:"title";s:16:"S03E05: Got It!!";s:3:"url";s:49:"http://aroundthebloc.podbean.com/e/s03e05-got-it/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-04 14:08:17.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:326:"2014 AFC Champions League winners!
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e06-the-d/</guid>
+		<description><![CDATA[<div>The trilogy has ended and we are Alan-less this week, as well as Ivan-less and Turner-less, not to mention still win-less in the A-league and Santalab-less, because he is shoulder-less. We can’t do much about missing podcasters or the need for surgery, but, like Seyi Adeleke, the Wanderers need to turn around and head in the right direction, and they can begin in Perth where they play the Glory this weekend.</div>
+<div></div>
+<div>One thing we are not missing this week is Speccy, who has returned from Riyadh to tell us a few tales of the road, and why he thinks Qatar should retain World Cup Hosting rights, and if you haven’t already turned this off to log onto twitter and abuse him for it, thanks for staying tuned - this is Around The Bloc</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"></div>
+]]></description>
+			<content:encoded><![CDATA[<div>The trilogy has ended and we are Alan-less this week, as well as Ivan-less and Turner-less, not to mention still win-less in the A-league and Santalab-less, because he is shoulder-less. We can’t do much about missing podcasters or the need for surgery, but, like Seyi Adeleke, the Wanderers need to turn around and head in the right direction, and they can begin in Perth where they play the Glory this weekend.</div>
+<div></div>
+<div>One thing we are not missing this week is Speccy, who has returned from Riyadh to tell us a few tales of the road, and why he thinks Qatar should retain World Cup Hosting rights, and if you haven’t already turned this off to log onto twitter and abuse him for it, thanks for staying tuned - this is Around The Bloc</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e06-the-d/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/ekpz94/S03E06_Around_the_Bloc_podcast.mp3" length="64533704" type="audio/mpeg"/>
+				<itunes:subtitle>The trilogy has ended and we are Alan-less this week, as well as Ivan-less and Turner-less, not to mention still win-less in the A-league and ...</itunes:subtitle>
+		<itunes:summary>The trilogy has ended and we are Alan-less this week, as well as Ivan-less and Turner-less, not to mention still win-less in the A-league and Santalab-less, because he is shoulder-less. We can't do much about missing podcasters or the need for surgery, but, like Seyi Adeleke, the Wanderers need to turn around and head in the right direction, and they can begin in Perth where they play the Glory this weekend.One thing we are not missing this week is Speccy, who has returned from Riyadh to tell us a few tales of the road, and why he thinks Qatar should retain World Cup Hosting rights, and if you haven't already turned this off to log onto twitter and abuse him for it, thanks for staying tuned - this is Around The Bloc</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:14:22</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E06: The D</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:6;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"bf53dfaace7e3c79364fbccdd436e5e0eabcaf952b682055fd7893dffc9f3976";s:5:"title";s:16:"S03E05: Got It!!";s:3:"url";s:49:"http://aroundthebloc.podbean.com/e/s03e05-got-it/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-11-04 14:08:17.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:326:"2014 AFC Champions League winners!
 <br/>Special Guest Alan Mtashar returns to complete the trilogy as we discuss the Wanderers’ historic victory in the AFC Champions League Final.
-<br/>There’s pride, tears, food, tangents and plenty of laughs. Pretty much everything you’d expect from another episode of Around The Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/siqdx3/S03E05_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<br/>There’s pride, tears, food, tangents and plenty of laughs. Pretty much everything you’d expect from another episode of Around The Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/siqdx3/S03E05_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:2883:"<item>
+		<title>S03E05: Got It!!</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e05-got-it/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e05-got-it/#comments</comments>
+		<pubDate>Tue, 04 Nov 2014 14:08:17 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:7;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"1fa34de3fad0a23dc00a3ec3a93afc984d92217f1adcb2c4dbe3d022ca6e5569";s:5:"title";s:29:"S03E04: Lights! Camera! Asia!";s:3:"url";s:61:"http://aroundthebloc.podbean.com/e/s03e04-lights-camera-asia/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-28 13:58:53.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:468:"With the spotlight on us, the crowd roared as we entered the arena and lined up on what was one of the biggest, most nerve wracking nights of our lives. The expectations were huge and the task ahead a gruelling one, but finally, after all the interviews were over, we readied ourselves and… we started recording the most important podcast of our lives. In front of ABC cameras no less.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e05-got-it/</guid>
+		<description><![CDATA[<div><font face="Arial, Verdana" size="2">2014 AFC Champions League winners!</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">Special Guest Alan Mtashar returns to complete the trilogy as we discuss the Wanderers’ historic victory in the AFC Champions League Final.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">There’s pride, tears, food, tangents and plenty of laughs. Pretty much everything you’d expect from another episode of Around The Bloc.</font></div>
+]]></description>
+			<content:encoded><![CDATA[<div><font face="Arial, Verdana" size="2">2014 AFC Champions League winners!</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">Special Guest Alan Mtashar returns to complete the trilogy as we discuss the Wanderers’ historic victory in the AFC Champions League Final.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">There’s pride, tears, food, tangents and plenty of laughs. Pretty much everything you’d expect from another episode of Around The Bloc.</font></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e05-got-it/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/siqdx3/S03E05_Around_the_Bloc_podcast.mp3" length="65136376" type="audio/mpeg"/>
+				<itunes:subtitle>2014 AFC Champions League winners!Special Guest Alan Mtashar returns to complete the trilogy as we discuss the Wanderers' historic victory in the AFC Champions League ...</itunes:subtitle>
+		<itunes:summary>2014 AFC Champions League winners!Special Guest Alan Mtashar returns to complete the trilogy as we discuss the Wanderers' historic victory in the AFC Champions League Final.There's pride, tears, food, tangents and plenty of laughs. Pretty much everything you'd expect from another episode of Around The Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:15:37</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E05: Got It!!</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:7;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"1fa34de3fad0a23dc00a3ec3a93afc984d92217f1adcb2c4dbe3d022ca6e5569";s:5:"title";s:29:"S03E04: Lights! Camera! Asia!";s:3:"url";s:61:"http://aroundthebloc.podbean.com/e/s03e04-lights-camera-asia/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-28 13:58:53.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:468:"With the spotlight on us, the crowd roared as we entered the arena and lined up on what was one of the biggest, most nerve wracking nights of our lives. The expectations were huge and the task ahead a gruelling one, but finally, after all the interviews were over, we readied ourselves and… we started recording the most important podcast of our lives. In front of ABC cameras no less.
 
 Oh and the Wanderers are taking a 1-0 lead to Riyadh.
 
-This is Around The Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/j4g9ts/S03E04_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+This is Around The Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/j4g9ts/S03E04_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3183:"<item>
+		<title>S03E04: Lights! Camera! Asia!</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e04-lights-camera-asia/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e04-lights-camera-asia/#comments</comments>
+		<pubDate>Tue, 28 Oct 2014 13:58:53 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:8;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"66ffaf3284073c2427fd65315713706dac76982bf0b6674c6e12c852a5ec799d";s:5:"title";s:26:"S03E03: Chuckin’ A Tanty";s:3:"url";s:58:"http://aroundthebloc.podbean.com/e/s03e03-chuckin-a-tanty/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-21 13:03:11.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:377:"Another bumper episode of Around the Bloc where we all have our turns at throwing a tantrum over the Derby D’Sydney result and officiating.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e04-lights-camera-asia/</guid>
+		<description><![CDATA[<div>With the spotlight on us, the crowd roared as we entered the arena and lined up on what was one of the biggest, most nerve wracking nights of our lives. The expectations were huge and the task ahead a gruelling one, but finally, after all the interviews were over, we readied ourselves and… we started recording the most important podcast of our lives. In front of ABC cameras no less.</div>
+<div></div>
+<div>Oh and the Wanderers are taking a 1-0 lead to Riyadh.</div>
+<div></div>
+<div>This is Around The Bloc.</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"></div>
+]]></description>
+			<content:encoded><![CDATA[<div>With the spotlight on us, the crowd roared as we entered the arena and lined up on what was one of the biggest, most nerve wracking nights of our lives. The expectations were huge and the task ahead a gruelling one, but finally, after all the interviews were over, we readied ourselves and… we started recording the most important podcast of our lives. In front of ABC cameras no less.</div>
+<div></div>
+<div>Oh and the Wanderers are taking a 1-0 lead to Riyadh.</div>
+<div></div>
+<div>This is Around The Bloc.</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e04-lights-camera-asia/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/j4g9ts/S03E04_Around_the_Bloc_podcast.mp3" length="66554286" type="audio/mpeg"/>
+				<itunes:subtitle>With the spotlight on us, the crowd roared as we entered the arena and lined up on what was one of the biggest, most nerve ...</itunes:subtitle>
+		<itunes:summary>With the spotlight on us, the crowd roared as we entered the arena and lined up on what was one of the biggest, most nerve wracking nights of our lives. The expectations were huge and the task ahead a gruelling one, but finally, after all the interviews were over, we readied ourselves and… we started recording the most important podcast of our lives. In front of ABC cameras no less.Oh and the Wanderers are taking a 1-0 lead to Riyadh.This is Around The Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:18:35</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E04: Lights! Camera! Asia!</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:8;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"66ffaf3284073c2427fd65315713706dac76982bf0b6674c6e12c852a5ec799d";s:5:"title";s:26:"S03E03: Chuckin’ A Tanty";s:3:"url";s:58:"http://aroundthebloc.podbean.com/e/s03e03-chuckin-a-tanty/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-21 13:03:11.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:377:"Another bumper episode of Around the Bloc where we all have our turns at throwing a tantrum over the Derby D’Sydney result and officiating.
 
 Most importantly though, special guest Alan Mtashar provides great insight into the world of Asian football and Al Hilal in particular, as we head towards the 1st leg of the 2014 Asian Champions League Final.
 
-This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/c5e7t3/S03E03_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+This is Around the Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/c5e7t3/S03E03_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:2645:"<item>
+		<title>S03E03: Chuckin’ A Tanty</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e03-chuckin-a-tanty/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e03-chuckin-a-tanty/#comments</comments>
+		<pubDate>Tue, 21 Oct 2014 13:03:11 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:9;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"9115b107427d30c99a64ca5abfc252255486062d45231b4c72fae905f244efda";s:5:"title";s:25:"S03E02: Sincerely, Speccy";s:3:"url";s:59:"http://aroundthebloc.podbean.com/e/s03e02-sincerely-speccy/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-14 12:32:20.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:741:"We lost to Melbourne on the weekend. Now, we’re not 1-4 negativity, but it was a pretty poor performance. It was, however, the first time we’ve actually conceded 4 goals but it didn’t seem to bother the 1,500 fans that travelled to see it.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e03-chuckin-a-tanty/</guid>
+		<description><![CDATA[<div>Another bumper episode of Around the Bloc where we all have our turns at throwing a tantrum over the Derby D’Sydney result and officiating.</div>
+<div></div>
+<div>Most importantly though, special guest Alan Mtashar provides great insight into the world of Asian football and Al Hilal in particular, as we head towards the 1st leg of the 2014 Asian Champions League Final.</div>
+<div></div>
+<div>This is Around the Bloc.</div>
+]]></description>
+			<content:encoded><![CDATA[<div>Another bumper episode of Around the Bloc where we all have our turns at throwing a tantrum over the Derby D’Sydney result and officiating.</div>
+<div></div>
+<div>Most importantly though, special guest Alan Mtashar provides great insight into the world of Asian football and Al Hilal in particular, as we head towards the 1st leg of the 2014 Asian Champions League Final.</div>
+<div></div>
+<div>This is Around the Bloc.</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e03-chuckin-a-tanty/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/c5e7t3/S03E03_Around_the_Bloc_podcast.mp3" length="69713458" type="audio/mpeg"/>
+				<itunes:subtitle>Another bumper episode of Around the Bloc where we all have our turns at throwing a tantrum over the Derby D'Sydney result and officiating.Most importantly ...</itunes:subtitle>
+		<itunes:summary>Another bumper episode of Around the Bloc where we all have our turns at throwing a tantrum over the Derby D'Sydney result and officiating.Most importantly though, special guest Alan Mtashar provides great insight into the world of Asian football and Al Hilal in particular, as we head towards the 1st leg of the 2014 Asian Champions League Final.This is Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:25:10</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E03: Chuckin’ A Tanty</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:9;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"9115b107427d30c99a64ca5abfc252255486062d45231b4c72fae905f244efda";s:5:"title";s:25:"S03E02: Sincerely, Speccy";s:3:"url";s:59:"http://aroundthebloc.podbean.com/e/s03e02-sincerely-speccy/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-14 12:32:20.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:741:"We lost to Melbourne on the weekend. Now, we’re not 1-4 negativity, but it was a pretty poor performance. It was, however, the first time we’ve actually conceded 4 goals but it didn’t seem to bother the 1,500 fans that travelled to see it.
 
 In other news, the W-League team beat Brisbane at Brisbane which is something the A-League squad hasn’t done in a while, and the Youth League squad beat Sydney, which could be a good omen for this weekend’s Derby - the first of the season. The RBB will once again descend (or stumble) upon the SFS in the hopes of taking 3 points home with them in the 8th edition of Popa vs the Smurfs. Will we turn their little village into Gargamel’s lair? Only time will tell.
 
-This is Around the Bloc";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/d294ej/S03E02_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:64:"
+This is Around the Bloc";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/d294ej/S03E02_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3781:"<item>
+		<title>S03E02: Sincerely, Speccy</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e02-sincerely-speccy/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e02-sincerely-speccy/#comments</comments>
+		<pubDate>Tue, 14 Oct 2014 12:32:20 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:10;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"7d1415a98b9df02cbf8fe90007b112af71a62e384417b056abdb24c0556dacb9";s:5:"title";s:40:"S03E01: Two Stars, New Stars, Old Tricks";s:3:"url";s:71:"http://aroundthebloc.podbean.com/e/s03e01-2-stars-new-stars-old-tricks/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-07 13:06:49.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:909:"<p>We’re back for a third season, and hopefully a third star on our logo. It’s been a really successful off season for both the podcast and the team we podcast about - Around the Bloc has won some silverware, but can the Wanderers? Only time will tell as we enter the home stretch of the Asian Champions League campaign, as well as the beginning of another A-League season.</p>
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e02-sincerely-speccy/</guid>
+		<description><![CDATA[<div>We lost to Melbourne on the weekend. Now, we’re not 1-4 negativity, but it was a pretty poor performance. It was, however, the first time we’ve actually conceded 4 goals but it didn’t seem to bother the 1,500 fans that travelled to see it.</div>
+<div></div>
+<div>In other news, the W-League team beat Brisbane at Brisbane which is something the A-League squad hasn’t done in a while, and the Youth League squad beat Sydney, which could be a good omen for this weekend’s Derby - the first of the season. The RBB will once again descend (or stumble) upon the SFS in the hopes of taking 3 points home with them in the 8th edition of Popa vs the Smurfs. Will we turn their little village into Gargamel’s lair? Only time will tell.</div>
+<div></div>
+<div>This is Around the Bloc</div>
+]]></description>
+			<content:encoded><![CDATA[<div>We lost to Melbourne on the weekend. Now, we’re not 1-4 negativity, but it was a pretty poor performance. It was, however, the first time we’ve actually conceded 4 goals but it didn’t seem to bother the 1,500 fans that travelled to see it.</div>
+<div></div>
+<div>In other news, the W-League team beat Brisbane at Brisbane which is something the A-League squad hasn’t done in a while, and the Youth League squad beat Sydney, which could be a good omen for this weekend’s Derby - the first of the season. The RBB will once again descend (or stumble) upon the SFS in the hopes of taking 3 points home with them in the 8th edition of Popa vs the Smurfs. Will we turn their little village into Gargamel’s lair? Only time will tell.</div>
+<div></div>
+<div>This is Around the Bloc</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e02-sincerely-speccy/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/d294ej/S03E02_Around_the_Bloc_podcast.mp3" length="57718132" type="audio/mpeg"/>
+				<itunes:subtitle>We lost to Melbourne on the weekend. Now, we're not 1-4 negativity, but it was a pretty poor performance. It was, however, the first time ...</itunes:subtitle>
+		<itunes:summary>We lost to Melbourne on the weekend. Now, we're not 1-4 negativity, but it was a pretty poor performance. It was, however, the first time we've actually conceded 4 goals but it didn't seem to bother the 1,500 fans that travelled to see it.In other news, the W-League team beat Brisbane at Brisbane which is something the A-League squad hasn't done in a while, and the Youth League squad beat Sydney, which could be a good omen for this weekend's Derby - the first of the season. The RBB will once again descend (or stumble) upon the SFS in the hopes of taking 3 points home with them in the 8th edition of Popa vs the Smurfs. Will we turn their little village into Gargamel's lair? Only time will tell.This is Around the Bloc</itunes:summary>
+		<itunes:keywords>A-League, Western Sydney Wanderers, football, soccer</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:00:11</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E02: Sincerely, Speccy</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:10;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"7d1415a98b9df02cbf8fe90007b112af71a62e384417b056abdb24c0556dacb9";s:5:"title";s:40:"S03E01: Two Stars, New Stars, Old Tricks";s:3:"url";s:71:"http://aroundthebloc.podbean.com/e/s03e01-2-stars-new-stars-old-tricks/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-10-07 13:06:49.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:909:"<p>We’re back for a third season, and hopefully a third star on our logo. It’s been a really successful off season for both the podcast and the team we podcast about - Around the Bloc has won some silverware, but can the Wanderers? Only time will tell as we enter the home stretch of the Asian Champions League campaign, as well as the beginning of another A-League season.</p>
 <p>On the other hand, the FFA Cup was an FFFail, Speccy’s first attempt at<a href="https://www.facebook.com/hashtag/atbbeers?source=feed_text&amp;story_id=376229905861058" rel="noreferrer" target="_blank">‪#‎ATBBeers‬</a> doesn’t quite go to plan, and all those cryptic clues that we put out on twitter that noone even really bothered to mention? Well, you’ll find out about that within the first few minutes of the show.</p>
 
-<p>We promise you, it’s worth a listen. This is the new season of Around the Bloc.</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/i8jpsr/S03E01_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<p>We promise you, it’s worth a listen. This is the new season of Around the Bloc.</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/i8jpsr/S03E01_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4291:"<item>
+		<title>S03E01: Two Stars, New Stars, Old Tricks</title>
+		<link>http://aroundthebloc.podbean.com/e/s03e01-2-stars-new-stars-old-tricks/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s03e01-2-stars-new-stars-old-tricks/#comments</comments>
+		<pubDate>Tue, 07 Oct 2014 13:06:49 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:11;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"42976d5465619da003c95e8009c8d3c151bc79b719e091bce22e308f5c0a26b4";s:5:"title";s:12:"S02E31: ENDS";s:3:"url";s:47:"http://aroundthebloc.podbean.com/e/s02e31-ends/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-05-19 01:22:03.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:819:"That’s it, the end of the 2013-14 season. There were highs, lows, transfers and releases, and still some potential silverware - and thats just for the podcast. The Wanderers had what, in hindsight, was a pretty successful sophomore season and are still in the running for the biggest prize on the continent - the AFC Champions League. 
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s03e01-2-stars-new-stars-old-tricks/</guid>
+		<description><![CDATA[<p style="margin:6px 0px;">We’re back for a third season, and hopefully a third star on our logo. It’s been a really successful off season for both the podcast and the team we podcast about - Around the Bloc has won some silverware, but can the Wanderers? Only time will tell as we enter the home stretch of the Asian Champions League campaign, as well as the beginning of another A-League season.</p>
+<p style="margin:6px 0px;">On the other hand, the FFA Cup was an FFFail, Speccy’s first attempt at<a class="_58cn" href="https://www.facebook.com/hashtag/atbbeers?source=feed_text&#38;story_id=376229905861058"><span class="_58cl">‪#‎</span><span class="_58cm">ATBBeers‬</span></a> do<span class="text_exposed_show">esn’t quite go to plan, and all those cryptic clues that we put out on twitter that noone even really bothered to mention? Well, you’ll find out about that within the first few minutes of the show.</span></p>
+<div class="text_exposed_show">
+<p></p></div>]]></description>
+			<content:encoded><![CDATA[<p style="margin:6px 0px;">We’re back for a third season, and hopefully a third star on our logo. It’s been a really successful off season for both the podcast and the team we podcast about - Around the Bloc has won some silverware, but can the Wanderers? Only time will tell as we enter the home stretch of the Asian Champions League campaign, as well as the beginning of another A-League season.</p>
+<p style="margin:6px 0px;">On the other hand, the FFA Cup was an FFFail, Speccy’s first attempt at<a class="_58cn" href="https://www.facebook.com/hashtag/atbbeers?source=feed_text&amp;story_id=376229905861058"><span class="_58cl">‪#‎</span><span class="_58cm">ATBBeers‬</span></a> do<span class="text_exposed_show">esn’t quite go to plan, and all those cryptic clues that we put out on twitter that noone even really bothered to mention? Well, you’ll find out about that within the first few minutes of the show.</span></p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">We promise you, it’s worth a listen. This is the new season of Around the Bloc.</p>
+</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s03e01-2-stars-new-stars-old-tricks/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/i8jpsr/S03E01_Around_the_Bloc_podcast.mp3" length="69915670" type="audio/mpeg"/>
+				<itunes:subtitle>We're back for a third season, and hopefully a third star on our logo. It's been a really successful off season for both the podcast ...</itunes:subtitle>
+		<itunes:summary>We're back for a third season, and hopefully a third star on our logo. It's been a really successful off season for both the podcast and the team we podcast about - Around the Bloc has won some silverware, but can the Wanderers? Only time will tell as we enter the home stretch of the Asian Champions League campaign, as well as the beginning of another A-League season.On the other hand, the FFA Cup was an FFFail, Speccy's first attempt at‪#‎ATBBeers‬ doesn't quite go to plan, and all those cryptic clues that we put out on twitter that noone even really bothered to mention? Well, you'll find out about that within the first few minutes of the show.We promise you, it's worth a listen. This is the new season of Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:25:39</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/28bcnk/ATBLogo-BlackBackground.png" medium="image">
+					<media:title type="html">S03E01: Two Stars, New Stars, Old Tricks</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:11;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"42976d5465619da003c95e8009c8d3c151bc79b719e091bce22e308f5c0a26b4";s:5:"title";s:12:"S02E31: ENDS";s:3:"url";s:47:"http://aroundthebloc.podbean.com/e/s02e31-ends/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-05-19 01:22:03.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:819:"That’s it, the end of the 2013-14 season. There were highs, lows, transfers and releases, and still some potential silverware - and thats just for the podcast. The Wanderers had what, in hindsight, was a pretty successful sophomore season and are still in the running for the biggest prize on the continent - the AFC Champions League. 
 <p>Thanks to everyone for listening this year. We’ll return next season with more puns, more laughs, more food talk and more <a href="https://www.facebook.com/hashtag/facts" rel="noreferrer" target="_blank">#facts</a>. Cheers from everyone here at Around the Bloc.</p>
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/sec79f/S02E31_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/sec79f/S02E31_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3856:"<item>
+		<title>S02E31: ENDS</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e31-ends/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e31-ends/#comments</comments>
+		<pubDate>Mon, 19 May 2014 01:22:03 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:12;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"feaf18e49146d1a11d5dd9ecab3dec75e907c4587ae054c3caeec27b3b6bfadc";s:5:"title";s:21:"S02E30: “…….”";s:3:"url";s:42:"http://aroundthebloc.podbean.com/e/s02e30/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-05-07 01:24:31.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:236:"….uuuugggghhhhhhh……
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s02e31-ends/</guid>
+		<description><![CDATA[<div><span>That’s it, the end of the 2013-14 season. There were highs, lows, transfers and releases, and still some potential silverware - and thats just for the podcast. The Wanderers had what, in hindsight, was a pretty successful sophomore season and are still in the running for the biggest prize on the continent - the AFC Champions League. </span>
+<p><span>Thanks to everyone for listening this year. We’ll return next season with more puns, more laughs, more food talk and more </span><a class="_58cn" dir="ltr" href="https://www.facebook.com/hashtag/facts"><span class="_58cl">#</span><span class="_58cm">facts</span></a><span>. Cheers from everyone here at Around the Bloc.</span></p></div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></description>
+			<content:encoded><![CDATA[<div><span>That’s it, the end of the 2013-14 season. There were highs, lows, transfers and releases, and still some potential silverware - and thats just for the podcast. The Wanderers had what, in hindsight, was a pretty successful sophomore season and are still in the running for the biggest prize on the continent - the AFC Champions League. </span>
+<p><span>Thanks to everyone for listening this year. We’ll return next season with more puns, more laughs, more food talk and more </span><a class="_58cn" dir="ltr" href="https://www.facebook.com/hashtag/facts"><span class="_58cl">#</span><span class="_58cm">facts</span></a><span>. Cheers from everyone here at Around the Bloc.</span></p></div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e31-ends/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/sec79f/S02E31_Around_the_Bloc_podcast.mp3" length="45656505" type="audio/mpeg"/>
+				<itunes:subtitle>That's it, the end of the 2013-14 season. There were highs, lows, transfers and releases, and still some potential silverware - and thats just for ...</itunes:subtitle>
+		<itunes:summary>That's it, the end of the 2013-14 season. There were highs, lows, transfers and releases, and still some potential silverware - and thats just for the podcast. The Wanderers had what, in hindsight, was a pretty successful sophomore season and are still in the running for the biggest prize on the continent - the AFC Champions League. Thanks to everyone for listening this year. We'll return next season with more puns, more laughs, more food talk and more #facts. Cheers from everyone here at Around the Bloc.Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:35:06</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E31: ENDS</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:12;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"feaf18e49146d1a11d5dd9ecab3dec75e907c4587ae054c3caeec27b3b6bfadc";s:5:"title";s:21:"S02E30: “…….”";s:3:"url";s:42:"http://aroundthebloc.podbean.com/e/s02e30/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-05-07 01:24:31.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:236:"….uuuugggghhhhhhh……
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/sbc8mh/S02E30_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/sbc8mh/S02E30_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:2021:"<item>
+		<title>S02E30: “…….”</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e30/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e30/#comments</comments>
+		<pubDate>Wed, 07 May 2014 01:24:31 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:13;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"1b5be6b5f3283a3e844ec9041a4b8abdb9c7705a659e7efcf3a0eff1ba859cf2";s:5:"title";s:17:"S02E29: Clown Car";s:3:"url";s:52:"http://aroundthebloc.podbean.com/e/s02e29-clown-car/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-30 01:20:12.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1170:"<p>We’re into the final! We’re going to Brisbane! We’re going to see JASON DERULO live! He’s going to say JASON DERULO heaps of times! I personally can’t wait, and the other 4,000 (and counting) Wanderers fans travelling up seem pretty keen as well.</p>
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/e/s02e30/</guid>
+		<description><![CDATA[<div>….uuuugggghhhhhhh……</div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></description>
+			<content:encoded><![CDATA[<div>….uuuugggghhhhhhh……</div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e30/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/sbc8mh/S02E30_Around_the_Bloc_podcast.mp3" length="44422272" type="audio/mpeg"/>
+				<itunes:subtitle>....uuuugggghhhhhhh......Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:subtitle>
+		<itunes:summary>....uuuugggghhhhhhh......Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:32:32</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E30: “…….”</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:13;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"1b5be6b5f3283a3e844ec9041a4b8abdb9c7705a659e7efcf3a0eff1ba859cf2";s:5:"title";s:17:"S02E29: Clown Car";s:3:"url";s:52:"http://aroundthebloc.podbean.com/e/s02e29-clown-car/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-30 01:20:12.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1170:"<p>We’re into the final! We’re going to Brisbane! We’re going to see JASON DERULO live! He’s going to say JASON DERULO heaps of times! I personally can’t wait, and the other 4,000 (and counting) Wanderers fans travelling up seem pretty keen as well.</p>
 
 <p>We got our Revenge on the Mariners, but it was anything but a Game of Thrones. We left them for Walking Dead, Breaking Bad through their defence and playing like Mad Men in order to come away with the 2-0 win. Brisbane will be doing their very best to Curb our Enthusiasm, but the Workaholic nature of our play will make it a very tough match. Will the Wanderers Family Guys be strong enough to overcome Berisha, the Total Diva, and his League of Gentlemen? With any luck, come Monday, we’ll all be talking about Roar’s ludicrous display and how they always try to walk it in.</p>
 <p><br/></p>
@@ -302,26 +443,42 @@ Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them ou
 
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/npjzx2/S02E29_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/npjzx2/S02E29_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3882:"<item>
+		<title>S02E29: Clown Car</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e29-clown-car/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e29-clown-car/#comments</comments>
+		<pubDate>Wed, 30 Apr 2014 01:20:12 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:14;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"6e4fa13ce5a9a6e64059b09aaebe4771a1fc3b4cb054c2acb2fa6575f24bf14a";s:5:"title";s:35:"S02E28: Big Trouble in Little China";s:3:"url";s:70:"http://aroundthebloc.podbean.com/e/s02e28-big-trouble-in-little-china/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-24 00:05:08.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:991:"<p>2nd in the League, 1st in our group in Asia, 1st in the stands and only a win away from our second consecutive grand final appearance - That’s right, we are almost at the end of the Wanderers worst season on record. The rotation policy, the ‘we’re a squad, not a team’ mentality - it will all hopefully be out the window next year as we play in our second successive ACL campaign.</p>
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/04/30/s02e29-clown-car/</guid>
+		<description><![CDATA[<div>
+<p style="margin:0px 0px 6px;">We’re into the final! We’re going to Brisbane! We’re going to see JASON DERULO live! He’s going to say JASON DERULO heaps of times! I personally can’t wait, and the other 4,000 (and counting) Wanderers fans travelling up seem pretty keen as well.</p>
+<p style="margin:0px 0px 6px;"></p>
+<p style="margin:0px 0px 6px;">We got our Revenge on the Mariners, but it was anything but a Game of Thrones. We left them for Walking Dead, Breaking Bad through their defence and playing like Mad Men in order to come away with the 2-0 win. Brisbane will b<span class="text_exposed_show">e doing their very best to Curb our Enthusiasm, but the Workaholic nature of our play will make it a very tough match. Will the Wanderers Family Guys be strong enough to overcome Berisha, the Total Diva, and his League of Gentlemen? With any luck, come Monday, we’ll all be talking about Roar’s ludicrous display and how they always try to walk i [...]</span></p></div>]]></description>
+			<content:encoded><![CDATA[<div>
+<p style="margin:0px 0px 6px;">We’re into the final! We’re going to Brisbane! We’re going to see JASON DERULO live! He’s going to say JASON DERULO heaps of times! I personally can’t wait, and the other 4,000 (and counting) Wanderers fans travelling up seem pretty keen as well.</p>
+<p style="margin:0px 0px 6px;"></p>
+<p style="margin:0px 0px 6px;">We got our Revenge on the Mariners, but it was anything but a Game of Thrones. We left them for Walking Dead, Breaking Bad through their defence and playing like Mad Men in order to come away with the 2-0 win. Brisbane will b<span class="text_exposed_show">e doing their very best to Curb our Enthusiasm, but the Workaholic nature of our play will make it a very tough match. Will the Wanderers Family Guys be strong enough to overcome Berisha, the Total Diva, and his League of Gentlemen? With any luck, come Monday, we’ll all be talking about Roar’s ludicrous display and how they always try to walk it in.</span></p>
+<p style="margin:0px 0px 6px;"><span class="text_exposed_show"><br /></span></p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">You’re listening to the It Crowd, AKA Brendan, Steve and Ivan on Around the Bloc.</p>
+</div>
+</div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e29-clown-car/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/npjzx2/S02E29_Around_the_Bloc_podcast.mp3" length="50685599" type="audio/mpeg"/>
+				<itunes:subtitle>We're into the final! We're going to Brisbane! We're going to see JASON DERULO live! He's going to say JASON DERULO heaps of times! I ...</itunes:subtitle>
+		<itunes:summary>The Official Supporters Podcast of the Western Sydney Wanderers</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:45:35</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E29: Clown Car</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:14;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"6e4fa13ce5a9a6e64059b09aaebe4771a1fc3b4cb054c2acb2fa6575f24bf14a";s:5:"title";s:35:"S02E28: Big Trouble in Little China";s:3:"url";s:70:"http://aroundthebloc.podbean.com/e/s02e28-big-trouble-in-little-china/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-24 00:05:08.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:991:"<p>2nd in the League, 1st in our group in Asia, 1st in the stands and only a win away from our second consecutive grand final appearance - That’s right, we are almost at the end of the Wanderers worst season on record. The rotation policy, the ‘we’re a squad, not a team’ mentality - it will all hopefully be out the window next year as we play in our second successive ACL campaign.</p>
 
 <p>In more positive news though, we finally got those 5 goals we were looking for against Guizhou, people power prevailed in getting the semi-final kick-off moved to a more football-player-friendly time, and we give you the answer to the question that everyone is asking - is it OK to wear a beret in the RBB?</p>
 <p><br/></p>
@@ -331,74 +488,125 @@ Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them ou
 
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/k8vfnj/S02E28_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/k8vfnj/S02E28_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4576:"<item>
+		<title>S02E28: Big Trouble in Little China</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e28-big-trouble-in-little-china/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e28-big-trouble-in-little-china/#comments</comments>
+		<pubDate>Thu, 24 Apr 2014 00:05:08 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:15;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"4d7a9c8f78633759e53ff8da7cc1c569dee7acd1aa2fef3f2deaeda470db1271";s:5:"title";s:31:"S02E27: Who Wears Black Shorts?";s:3:"url";s:65:"http://aroundthebloc.podbean.com/e/s02e27-who-wears-black-shorts/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-16 01:28:54.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:959:"Great Scott! The Wanderers took 3 points away from both Melbourne and Korea this week in two epic performances which had us podcasters travelling through space and time to talk about them, whilst the travelling RBB went for a McFly to either destination, and thankfully nobody had to see a Doc or got involved in any Biff. On the pitch, the team was good enough not to Fox things up, apart from Shinji Ono, who’s number you get if you add Tannen eleven, who had a minor issue with the crossbar.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/04/24/s02e28-big-trouble-in-little-china/</guid>
+		<description><![CDATA[<div>
+<p style="margin:6px 0px;">2nd in the League, 1st in our group in Asia, 1st in the stands and only a win away from our second consecutive grand final appearance - That’s right, we are almost at the end of the Wanderers worst season on record. The rotation policy, the ‘we’re a squad, not a team’ mentality - it will all hopefully be out the window next year as we play in our second successive ACL campaign.</p>
+<p style="margin:6px 0px;"></p>
+<p style="margin:6px 0px;">In more positive news though, we finally got those 5 goals we were looking for against Guiz<span class="text_exposed_show">hou, people power prevailed in getting the semi-final kick-off moved to a more football-player-friendly time, and we give you the answer to the question that everyone is asking - is it OK to wear a beret in the RBB?</span></p>
+<p style="margin:6px 0px;"><span class="text_exposed_show"><br /></span></p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">Merci po [...]</p></div></div>]]></description>
+			<content:encoded><![CDATA[<div>
+<p style="margin:6px 0px;">2nd in the League, 1st in our group in Asia, 1st in the stands and only a win away from our second consecutive grand final appearance - That’s right, we are almost at the end of the Wanderers worst season on record. The rotation policy, the ‘we’re a squad, not a team’ mentality - it will all hopefully be out the window next year as we play in our second successive ACL campaign.</p>
+<p style="margin:6px 0px;"></p>
+<p style="margin:6px 0px;">In more positive news though, we finally got those 5 goals we were looking for against Guiz<span class="text_exposed_show">hou, people power prevailed in getting the semi-final kick-off moved to a more football-player-friendly time, and we give you the answer to the question that everyone is asking - is it OK to wear a beret in the RBB?</span></p>
+<p style="margin:6px 0px;"><span class="text_exposed_show"><br /></span></p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">Merci pour l’écoute, c’est Autour du Bloc</p>
+</div>
+</div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e28-big-trouble-in-little-china/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/k8vfnj/S02E28_Around_the_Bloc_podcast.mp3" length="36584283" type="audio/mpeg"/>
+				<itunes:subtitle>2nd in the League, 1st in our group in Asia, 1st in the stands and only a win away from our second consecutive grand final ...</itunes:subtitle>
+		<itunes:summary>2nd in the League, 1st in our group in Asia, 1st in the stands and only a win away from our second consecutive grand final appearance - That's right, we are almost at the end of the Wanderers worst season on record. The rotation policy, the 'we're a squad, not a team' mentality - it will all hopefully be out the window next year as we play in our second successive ACL campaign.In more positive news though, we finally got those 5 goals we were looking for against Guizhou, people power prevailed in getting the semi-final kick-off moved to a more football-player-friendly time, and we give you the answer to the question that everyone is asking - is it OK to wear a beret in the RBB?Merci pour l'écoute, c'est Autour du BlocThanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:16:12</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E28: Big Trouble in Little China</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:15;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"4d7a9c8f78633759e53ff8da7cc1c569dee7acd1aa2fef3f2deaeda470db1271";s:5:"title";s:31:"S02E27: Who Wears Black Shorts?";s:3:"url";s:65:"http://aroundthebloc.podbean.com/e/s02e27-who-wears-black-shorts/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-16 01:28:54.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:959:"Great Scott! The Wanderers took 3 points away from both Melbourne and Korea this week in two epic performances which had us podcasters travelling through space and time to talk about them, whilst the travelling RBB went for a McFly to either destination, and thankfully nobody had to see a Doc or got involved in any Biff. On the pitch, the team was good enough not to Fox things up, apart from Shinji Ono, who’s number you get if you add Tannen eleven, who had a minor issue with the crossbar.
 <br/>So with the team shoring up 2nd spot in the A-League, and one more round to go in the ACL, we would need some sort of sports almanac to predict what’s going to happen in the coming weeks. You’ll just have to stay tuned to Around the Bloc.
 <br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/5b4fdx/S02E27_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/5b4fdx/S02E27_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4612:"<item>
+		<title>S02E27: Who Wears Black Shorts?</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e27-who-wears-black-shorts/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e27-who-wears-black-shorts/#comments</comments>
+		<pubDate>Wed, 16 Apr 2014 01:28:54 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:16;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"50b43fbd9eb1b6a8a3db60e1fc87ae2bf213e3da7ea042c884624a47ea123879";s:5:"title";s:20:"S02E26: Gold Edition";s:3:"url";s:55:"http://aroundthebloc.podbean.com/e/s02e26-gold-edition/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-09 00:25:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:903:"<p>The Wanderers managed a 1-1 draw with the top of the table Brisbane Roar, but it was only an afterthought compared to the farewell given to Tensai by the RBB and the club. The fans chanted, made banners, and clapped along for our man, whilst the club held a pyro party in the sky in true Western Sydney form.</p>
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/04/16/s02e27-who-wears-black-shorts/</guid>
+		<description><![CDATA[<div><font face="Arial, Verdana" size="2">Great Scott! The Wanderers took 3 points away from both Melbourne and Korea this week in two epic performances which had us podcasters travelling through space and time to talk about them, whilst the travelling RBB went for a McFly to either destination, and thankfully nobody had to see a Doc or got involved in any Biff. On the pitch, the team was good enough not to Fox things up, apart from Shinji Ono, who’s number you get if you add Tannen eleven, who had a minor issue with the crossbar.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">So with the team shoring up 2nd spot in the A-League, and one more round to go in the ACL, we would need some sort of sports almanac to predict what’s going to happen in the coming weeks. You’ll just have to stay tuned to Around the Bloc.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div>
+<div></div></div>]]></description>
+			<content:encoded><![CDATA[<div><font face="Arial, Verdana" size="2">Great Scott! The Wanderers took 3 points away from both Melbourne and Korea this week in two epic performances which had us podcasters travelling through space and time to talk about them, whilst the travelling RBB went for a McFly to either destination, and thankfully nobody had to see a Doc or got involved in any Biff. On the pitch, the team was good enough not to Fox things up, apart from Shinji Ono, who’s number you get if you add Tannen eleven, who had a minor issue with the crossbar.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">So with the team shoring up 2nd spot in the A-League, and one more round to go in the ACL, we would need some sort of sports almanac to predict what’s going to happen in the coming weeks. You’ll just have to stay tuned to Around the Bloc.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div>
+<div style="font-family:Arial, Verdana;font-size:13px;">Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div style="font-family:Arial, Verdana;font-size:13px;"><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e27-who-wears-black-shorts/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/5b4fdx/S02E27_Around_the_Bloc_podcast.mp3" length="43258255" type="audio/mpeg"/>
+				<itunes:subtitle>Great Scott! The Wanderers took 3 points away from both Melbourne and Korea this week in two epic performances which had us podcasters travelling through ...</itunes:subtitle>
+		<itunes:summary>Great Scott! The Wanderers took 3 points away from both Melbourne and Korea this week in two epic performances which had us podcasters travelling through space and time to talk about them, whilst the travelling RBB went for a McFly to either destination, and thankfully nobody had to see a Doc or got involved in any Biff. On the pitch, the team was good enough not to Fox things up, apart from Shinji Ono, who's number you get if you add Tannen eleven, who had a minor issue with the crossbar.So with the team shoring up 2nd spot in the A-League, and one more round to go in the ACL, we would need some sort of sports almanac to predict what's going to happen in the coming weeks. You'll just have to stay tuned to Around the Bloc.Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:30:07</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E27: Who Wears Black Shorts?</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:16;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"50b43fbd9eb1b6a8a3db60e1fc87ae2bf213e3da7ea042c884624a47ea123879";s:5:"title";s:20:"S02E26: Gold Edition";s:3:"url";s:55:"http://aroundthebloc.podbean.com/e/s02e26-gold-edition/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-09 00:25:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:903:"<p>The Wanderers managed a 1-1 draw with the top of the table Brisbane Roar, but it was only an afterthought compared to the farewell given to Tensai by the RBB and the club. The fans chanted, made banners, and clapped along for our man, whilst the club held a pyro party in the sky in true Western Sydney form.</p>
 
 <p>Someone does some ranting this week, although we’re not going to give him any credit for it, and vaccinations affect my ability to pun throughout the intro. Speaking of diseases though, the Yellow Fever podcast is up for a gong at this years FFDU awards, along with the A-League Show and of course, carry-over champs, Around the Bloc - which is starting right now.</p>
 
 
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/wzs7hr/S02E26_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/wzs7hr/S02E26_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4252:"<item>
+		<title>S02E26: Gold Edition</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e26-gold-edition/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e26-gold-edition/#comments</comments>
+		<pubDate>Wed, 09 Apr 2014 00:25:02 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:17;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"7ee45f73d75c53e8742282bde3b77858d697130034305cb8217a3925f29a25ee";s:5:"title";s:23:"S02E25: Twist and Shout";s:3:"url";s:58:"http://aroundthebloc.podbean.com/e/s02e25-twist-and-shout/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-03 01:40:34.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1067:"<p>I get by with a little help from my friend Ivan on this week’s podcast, as Steve is on his way back from the USSR… or Japan, and Turner’s off being a paperback writer or something.</p>
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/04/09/s02e26-gold-edition/</guid>
+		<description><![CDATA[<div>
+<p style="margin:6px 0px;">The Wanderers managed a 1-1 draw with the top of the table Brisbane Roar, but it was only an afterthought compared to the farewell given to Tensai by the RBB and the club. The fans chanted, made banners, and clapped along for our man, wh<span class="text_exposed_show">ilst the club held a pyro party in the sky in true Western Sydney form.</span></p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">Someone does some ranting this week, although we’re not going to give him any credit for it, and vaccinations affect my ability to pun throughout the intro. Speaking of diseases though, the Yellow Fever podcast is up for a gong at this years FFDU awards, along with the A-League Show and of course, carry-over champs, Around the Bloc - which is starting right now.</p>
+</div>
+</div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencater%20%5B...%5D"></a></div>]]></description>
+			<content:encoded><![CDATA[<div>
+<p style="margin:6px 0px;">The Wanderers managed a 1-1 draw with the top of the table Brisbane Roar, but it was only an afterthought compared to the farewell given to Tensai by the RBB and the club. The fans chanted, made banners, and clapped along for our man, wh<span class="text_exposed_show">ilst the club held a pyro party in the sky in true Western Sydney form.</span></p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">Someone does some ranting this week, although we’re not going to give him any credit for it, and vaccinations affect my ability to pun throughout the intro. Speaking of diseases though, the Yellow Fever podcast is up for a gong at this years FFDU awards, along with the A-League Show and of course, carry-over champs, Around the Bloc - which is starting right now.</p>
+</div>
+</div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e26-gold-edition/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/wzs7hr/S02E26_Around_the_Bloc_podcast.mp3" length="48672498" type="audio/mpeg"/>
+				<itunes:subtitle>The Wanderers managed a 1-1 draw with the top of the table Brisbane Roar, but it was only an afterthought compared to the farewell given ...</itunes:subtitle>
+		<itunes:summary>The Wanderers managed a 1-1 draw with the top of the table Brisbane Roar, but it was only an afterthought compared to the farewell given to Tensai by the RBB and the club. The fans chanted, made banners, and clapped along for our man, whilst the club held a pyro party in the sky in true Western Sydney form.Someone does some ranting this week, although we're not going to give him any credit for it, and vaccinations affect my ability to pun throughout the intro. Speaking of diseases though, the Yellow Fever podcast is up for a gong at this years FFDU awards, along with the A-League Show and of course, carry-over champs, Around the Bloc - which is starting right now.Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:41:23</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E26: Gold Edition</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:17;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"7ee45f73d75c53e8742282bde3b77858d697130034305cb8217a3925f29a25ee";s:5:"title";s:23:"S02E25: Twist and Shout";s:3:"url";s:58:"http://aroundthebloc.podbean.com/e/s02e25-twist-and-shout/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-04-03 01:40:34.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1067:"<p>I get by with a little help from my friend Ivan on this week’s podcast, as Steve is on his way back from the USSR… or Japan, and Turner’s off being a paperback writer or something.</p>
 
 <p>For starters, a huge shout out to the travelling RBB who went on a magical mystery tour to Japan. It made us all proud to see them standing there and we all wished we’d bought a ticket to ride</p>
 
@@ -410,99 +618,159 @@ Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them ou
 
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/edwk8g/S02E25_Around_The_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/edwk8g/S02E25_Around_The_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4643:"<item>
+		<title>S02E25: Twist and Shout</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e25-twist-and-shout/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e25-twist-and-shout/#comments</comments>
+		<pubDate>Thu, 03 Apr 2014 01:40:34 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:18;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"4d4ae1939ffffce8cd9279845674445ef36d8e673b1892727cef413fdd512310";s:5:"title";s:22:"S02E24: -title banned-";s:3:"url";s:42:"http://aroundthebloc.podbean.com/e/s02e24/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-26 00:10:32.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1023:"<p>The Premiers Plate is firmly in the hands of the Brisbane Roar, but the Wanderers haven’t left the table just yet, and like a new vegan’s eggs, they’re unbeaten in recent times. The team will have to get their knife and fork into the upcoming fixtures against Mariners and Kawasaki, both of which will be tougher than a $2 steak. Only time will tell if they’re able to repeat history, score early and pork the bus.</p>
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/04/03/s02e25-twist-and-shout/</guid>
+		<description><![CDATA[<div>
+<p style="margin:6px 0px;">I get by with a little help from my friend Ivan on this week’s podcast, as Steve is on his way back from the USSR… or Japan, and Turner’s off being a paperback writer or something.</p>
+<p style="margin:6px 0px;"></p>
+<p style="margin:6px 0px;">For starters, a huge shout out to the travelling RBB who went on a magical mystery tour to Japan. It made us all proud to see them standing there and we all wished we’d bought a ticket to ride</p>
+<p style="margin:6px 0px;"></p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">Unfortunately though, it’s been a couple of hard day’s nights for the Wanderers, who are gently weeping after two consecutive losses to late goals, and that has left some fans refusing to give them all their loving. The team won’t be able to buy their love though, so Sgt Popa’s Lonely Hearts Club Band will have to earn it back with a good performance against the Roar on the weeken [...]</p></div></div>]]></description>
+			<content:encoded><![CDATA[<div>
+<p style="margin:6px 0px;">I get by with a little help from my friend Ivan on this week’s podcast, as Steve is on his way back from the USSR… or Japan, and Turner’s off being a paperback writer or something.</p>
+<p style="margin:6px 0px;"></p>
+<p style="margin:6px 0px;">For starters, a huge shout out to the travelling RBB who went on a magical mystery tour to Japan. It made us all proud to see them standing there and we all wished we’d bought a ticket to ride</p>
+<p style="margin:6px 0px;"></p>
+<div class="text_exposed_show">
+<p style="margin:0px 0px 6px;">Unfortunately though, it’s been a couple of hard day’s nights for the Wanderers, who are gently weeping after two consecutive losses to late goals, and that has left some fans refusing to give them all their loving. The team won’t be able to buy their love though, so Sgt Popa’s Lonely Hearts Club Band will have to earn it back with a good performance against the Roar on the weekend.</p>
+<p style="margin:0px 0px 6px;"></p>
+<p style="margin:6px 0px;">We are the Walrus, and this is Around the Bloc</p>
+<p style="margin:6px 0px;"></p>
+</div>
+</div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e25-twist-and-shout/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/edwk8g/S02E25_Around_The_Bloc_podcast.mp3" length="33779232" type="audio/mpeg"/>
+				<itunes:subtitle>I get by with a little help from my friend Ivan on this week's podcast, as Steve is on his way back from the USSR... ...</itunes:subtitle>
+		<itunes:summary>I get by with a little help from my friend Ivan on this week's podcast, as Steve is on his way back from the USSR... or Japan, and Turner's off being a paperback writer or something.For starters, a huge shout out to the travelling RBB who went on a magical mystery tour to Japan. It made us all proud to see them standing there and we all wished we'd bought a ticket to rideUnfortunately though, it's been a couple of hard day's nights for the Wanderers, who are gently weeping after two consecutive losses to late goals, and that has left some fans refusing to give them all their loving. The team won't be able to buy their love though, so Sgt Popa's Lonely Hearts Club Band will have to earn it back with a good performance against the Roar on the weekend.We are the Walrus, and this is Around the BlocThanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:10:22</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E25: Twist and Shout</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:18;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"4d4ae1939ffffce8cd9279845674445ef36d8e673b1892727cef413fdd512310";s:5:"title";s:22:"S02E24: -title banned-";s:3:"url";s:42:"http://aroundthebloc.podbean.com/e/s02e24/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-26 00:10:32.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1023:"<p>The Premiers Plate is firmly in the hands of the Brisbane Roar, but the Wanderers haven’t left the table just yet, and like a new vegan’s eggs, they’re unbeaten in recent times. The team will have to get their knife and fork into the upcoming fixtures against Mariners and Kawasaki, both of which will be tougher than a $2 steak. Only time will tell if they’re able to repeat history, score early and pork the bus.</p>
 <p>Speaking of pigs, Cop Watch makes an unwanted return this week, as nobody’s scarf, shoes, socks, or 12 year old daughters are safe from the weekly pat-down that Western Sydney’s loyal football fans are subjected to.</p>
 <p>So sit in your allocated seat, refrain from talking or moving - you’re going to listen to this weeks Around the Bloc, whether you like it or not.</p>
 
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/fmhy3u/S02E24_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/fmhy3u/S02E24_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4475:"<item>
+		<title>S02E24: -title banned-</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e24/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e24/#comments</comments>
+		<pubDate>Wed, 26 Mar 2014 00:10:32 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:19;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"b16174ac1cb7f0351971e09121c32830020b6fdbca84f15e26f217899a48f951";s:5:"title";s:21:"S02E23: Shoot F*rken!";s:3:"url";s:54:"http://aroundthebloc.podbean.com/e/s02e23-shoot-frken/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-18 23:18:15.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:708:"Unlike Mebrahtu, the Wanderers are starting to look strong in the ACL, something I’m sure Golgol won’t find humerus. Ulna-ther news, the team is finding the A-League tough, but maybe they should listen to us when we keep patella-n them to shoot. After all, some goals would’ve been nice as the RBB were going out and they were dancing in the storm, getting soaked to the bone in the process.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/03/26/s02e24/</guid>
+		<description><![CDATA[<div>
+<p style="margin:6px 0px;">The Premiers Plate is firmly in the hands of the Brisbane Roar, but the Wanderers haven’t left the table just yet, and like a new vegan’s eggs, they’re unbeaten in recent times. The team will have to get their knife and fork into the upcoming fixtures against Mariners and Kawasaki, both of which will be tougher than a $2 steak. Only time will tell if they’re able to repeat history, score early and pork the bus.</p>
+<p style="margin:6px 0px;"><span style="font-size:10pt;">Speaking of pigs, Cop Watch makes an unwanted return this w</span><span class="text_exposed_show" style="font-size:10pt;">eek, as nobody’s scarf, shoes, socks, or 12 year old daughters are safe from the weekly pat-down that Western Sydney’s loyal football fans are subjected to.</span></p>
+<p style="margin:6px 0px;"><span style="font-size:10pt;">So sit in your allocated seat, refrain from talking or moving - you’re going to listen to this weeks A [...]</span></p></div>]]></description>
+			<content:encoded><![CDATA[<div>
+<p style="margin:6px 0px;">The Premiers Plate is firmly in the hands of the Brisbane Roar, but the Wanderers haven’t left the table just yet, and like a new vegan’s eggs, they’re unbeaten in recent times. The team will have to get their knife and fork into the upcoming fixtures against Mariners and Kawasaki, both of which will be tougher than a $2 steak. Only time will tell if they’re able to repeat history, score early and pork the bus.</p>
+<p style="margin:6px 0px;"><span style="font-size:10pt;">Speaking of pigs, Cop Watch makes an unwanted return this w</span><span class="text_exposed_show" style="font-size:10pt;">eek, as nobody’s scarf, shoes, socks, or 12 year old daughters are safe from the weekly pat-down that Western Sydney’s loyal football fans are subjected to.</span></p>
+<p style="margin:6px 0px;"><span style="font-size:10pt;">So sit in your allocated seat, refrain from talking or moving - you’re going to listen to this weeks Around the Bloc, whether you like it or not.</span></p>
+</div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e24/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/fmhy3u/S02E24_Around_the_Bloc_podcast.mp3" length="49512387" type="audio/mpeg"/>
+				<itunes:subtitle>The Premiers Plate is firmly in the hands of the Brisbane Roar, but the Wanderers haven't left the table just yet, and like a new ...</itunes:subtitle>
+		<itunes:summary>The Premiers Plate is firmly in the hands of the Brisbane Roar, but the Wanderers haven't left the table just yet, and like a new vegan's eggs, they're unbeaten in recent times. The team will have to get their knife and fork into the upcoming fixtures against Mariners and Kawasaki, both of which will be tougher than a $2 steak. Only time will tell if they're able to repeat history, score early and pork the bus.Speaking of pigs, Cop Watch makes an unwanted return this week, as nobody's scarf, shoes, socks, or 12 year old daughters are safe from the weekly pat-down that Western Sydney's loyal football fans are subjected to.So sit in your allocated seat, refrain from talking or moving - you're going to listen to this weeks Around the Bloc, whether you like it or not.Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:43:08</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E24: -title banned-</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:19;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"b16174ac1cb7f0351971e09121c32830020b6fdbca84f15e26f217899a48f951";s:5:"title";s:21:"S02E23: Shoot F*rken!";s:3:"url";s:54:"http://aroundthebloc.podbean.com/e/s02e23-shoot-frken/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-18 23:18:15.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:708:"Unlike Mebrahtu, the Wanderers are starting to look strong in the ACL, something I’m sure Golgol won’t find humerus. Ulna-ther news, the team is finding the A-League tough, but maybe they should listen to us when we keep patella-n them to shoot. After all, some goals would’ve been nice as the RBB were going out and they were dancing in the storm, getting soaked to the bone in the process.
 <p>There’s rants galore and much more, so skull your drink and get ready for Around the Bloc.</p>
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/kagis8/S02E23_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/kagis8/S02E23_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3648:"<item>
+		<title>S02E23: Shoot F*rken!</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e23-shoot-frken/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e23-shoot-frken/#comments</comments>
+		<pubDate>Tue, 18 Mar 2014 23:18:15 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:20;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"9ee35d69ce31c9864ce726904626b558e70adf7dc6f775abc576006ee2912537";s:5:"title";s:31:"S02E22: To Sydney, with love…";s:3:"url";s:62:"http://aroundthebloc.podbean.com/e/s02e22-to-sydney-with-love/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-11 22:58:23.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:937:"Sydney FC won the third Sydney Derby of the season thanks to the Wanderers playing like d’apu-zzo they left Allianz Stadium with their tail between their legs, knowing they won’t go top-or close to it for at least another week. The atmosphere was, as the French say, La Rocca’n, and the 40,000 that packed the ground left the NRL journo’s saying ‘Ono!’, just like Meggsy said after that through ball to Garcia. It was a Bridge too far for the Wanderers though, and Santa came early for the Sky Blue side of Sydney.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/03/19/s02e23-shoot-frken/</guid>
+		<description><![CDATA[<div><span><span>Unlike Mebrahtu, the Wanderers are starting to look strong in the ACL, something I’m sure Golgol won’t find humerus. Ulna-ther news, the team is finding the A-League tough, but maybe they should listen to us when we keep patella-n t</span></span><span><span><span>hem to shoot. After all, some goals would’ve been nice as the RBB were going out and they were dancing in the storm, getting soaked to the bone in the process.</span>
+</span></span><p><span>There’s rants galore and much more, so skull your drink and get ready for Around the Bloc.</span></p></div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></description>
+			<content:encoded><![CDATA[<div><span><span>Unlike Mebrahtu, the Wanderers are starting to look strong in the ACL, something I’m sure Golgol won’t find humerus. Ulna-ther news, the team is finding the A-League tough, but maybe they should listen to us when we keep patella-n t</span></span><span><span><span>hem to shoot. After all, some goals would’ve been nice as the RBB were going out and they were dancing in the storm, getting soaked to the bone in the process.</span>
+</span></span><p><span>There’s rants galore and much more, so skull your drink and get ready for Around the Bloc.</span></p></div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e23-shoot-frken/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/kagis8/S02E23_Around_the_Bloc_podcast.mp3" length="39982291" type="audio/mpeg"/>
+				<itunes:subtitle>Unlike Mebrahtu, the Wanderers are starting to look strong in the ACL, something I'm sure Golgol won't find humerus. Ulna-ther news, the team is finding ...</itunes:subtitle>
+		<itunes:summary>Unlike Mebrahtu, the Wanderers are starting to look strong in the ACL, something I'm sure Golgol won't find humerus. Ulna-ther news, the team is finding the A-League tough, but maybe they should listen to us when we keep patella-n them to shoot. After all, some goals would've been nice as the RBB were going out and they were dancing in the storm, getting soaked to the bone in the process.There's rants galore and much more, so skull your drink and get ready for Around the Bloc.Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:23:17</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E23: Shoot F*rken!</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:20;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"9ee35d69ce31c9864ce726904626b558e70adf7dc6f775abc576006ee2912537";s:5:"title";s:31:"S02E22: To Sydney, with love…";s:3:"url";s:62:"http://aroundthebloc.podbean.com/e/s02e22-to-sydney-with-love/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-11 22:58:23.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:937:"Sydney FC won the third Sydney Derby of the season thanks to the Wanderers playing like d’apu-zzo they left Allianz Stadium with their tail between their legs, knowing they won’t go top-or close to it for at least another week. The atmosphere was, as the French say, La Rocca’n, and the 40,000 that packed the ground left the NRL journo’s saying ‘Ono!’, just like Meggsy said after that through ball to Garcia. It was a Bridge too far for the Wanderers though, and Santa came early for the Sky Blue side of Sydney.
 <br/>Finally, the Red and Black hoops are off to China to ask ‘Guizhou, where you goin’ with that gun in your hand?’ and then back to play Adelaide at Wanderland.
 <br/>This is Around the Bloc.
 
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/znutb3/S02E22_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/znutb3/S02E22_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4865:"<item>
+		<title>S02E22: To Sydney, with love…</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e22-to-sydney-with-love/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e22-to-sydney-with-love/#comments</comments>
+		<pubDate>Tue, 11 Mar 2014 22:58:23 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:21;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"16517eb672c6227c772d6b75bb18e5f40d6617384419ca252b04b7c152e56cc0";s:5:"title";s:29:"S02E21: La Banda-ing Together";s:3:"url";s:64:"http://aroundthebloc.podbean.com/e/s02e21-la-banda-ing-together/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-05 02:25:30.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1006:"A huge episode this week as two members of the RBB’s band, La Banda, join us to share their opinions on all the on and off the pitch happenings, which they drum into us, and are generally bass’d on their experiences in the RBB. Having been one of the cymbals of the active supporter group since day 1, they try not to repinique themselves as they recall how they formed, how the chants come together, and why they, for some reason, love Tom-Tomi Juric.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/03/12/s02e22-to-sydney-with-love/</guid>
+		<description><![CDATA[<div>
+<div><font face="Arial, Verdana" size="2">Sydney FC won the third Sydney Derby of the season thanks to the Wanderers playing like d’apu-zzo they left Allianz Stadium with their tail between their legs, knowing they won’t go top-or close to it for at least another week. The atmosphere was, as the French say, La Rocca’n, and the 40,000 that packed the ground left the NRL journo’s saying ‘Ono!’, just like Meggsy said after that through ball to Garcia. It was a Bridge too far for the Wanderers though, and Santa came early for the Sky Blue side of Sydney.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">Finally, the Red and Black hoops are off to China to ask ‘Guizhou, where you goin’ with that gun in your hand?’ and then back to play Adelaide at Wanderland.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana"></font></div></div>]]></description>
+			<content:encoded><![CDATA[<div>
+<div><font face="Arial, Verdana" size="2">Sydney FC won the third Sydney Derby of the season thanks to the Wanderers playing like d’apu-zzo they left Allianz Stadium with their tail between their legs, knowing they won’t go top-or close to it for at least another week. The atmosphere was, as the French say, La Rocca’n, and the 40,000 that packed the ground left the NRL journo’s saying ‘Ono!’, just like Meggsy said after that through ball to Garcia. It was a Bridge too far for the Wanderers though, and Santa came early for the Sky Blue side of Sydney.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">Finally, the Red and Black hoops are off to China to ask ‘Guizhou, where you goin’ with that gun in your hand?’ and then back to play Adelaide at Wanderland.</font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">This is Around the Bloc.</font></div>
+</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"></div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;">Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e22-to-sydney-with-love/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/znutb3/S02E22_Around_the_Bloc_podcast.mp3" length="39093083" type="audio/mpeg"/>
+				<itunes:subtitle>Sydney FC won the third Sydney Derby of the season thanks to the Wanderers playing like d'apu-zzo they left Allianz Stadium with their tail between ...</itunes:subtitle>
+		<itunes:summary>Sydney FC won the third Sydney Derby of the season thanks to the Wanderers playing like d'apu-zzo they left Allianz Stadium with their tail between their legs, knowing they won't go top-or close to it for at least another week. The atmosphere was, as the French say, La Rocca'n, and the 40,000 that packed the ground left the NRL journo's saying 'Ono!', just like Meggsy said after that through ball to Garcia. It was a Bridge too far for the Wanderers though, and Santa came early for the Sky Blue side of Sydney.Finally, the Red and Black hoops are off to China to ask 'Guizhou, where you goin' with that gun in your hand?' and then back to play Adelaide at Wanderland.This is Around the Bloc.Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:21:26</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E22: To Sydney, with love…</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:21;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"16517eb672c6227c772d6b75bb18e5f40d6617384419ca252b04b7c152e56cc0";s:5:"title";s:29:"S02E21: La Banda-ing Together";s:3:"url";s:64:"http://aroundthebloc.podbean.com/e/s02e21-la-banda-ing-together/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-03-05 02:25:30.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1006:"A huge episode this week as two members of the RBB’s band, La Banda, join us to share their opinions on all the on and off the pitch happenings, which they drum into us, and are generally bass’d on their experiences in the RBB. Having been one of the cymbals of the active supporter group since day 1, they try not to repinique themselves as they recall how they formed, how the chants come together, and why they, for some reason, love Tom-Tomi Juric.
 
 Also on the show……………………………………………….. thats right - the silent protest. We delve into the why, the who, what, when, the where and the how, as we were all grabbing our hair and tearing it out wondering what the hell was going on. 
 
@@ -511,203 +779,334 @@ Sit back, relax and drop it like it’s hot - this is Around the Bloc
 
 Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:
 
-<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/4b9fyv/S02E21_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/4b9fyv/S02E21_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4489:"<item>
+		<title>S02E21: La Banda-ing Together</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e21-la-banda-ing-together/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e21-la-banda-ing-together/#comments</comments>
+		<pubDate>Wed, 05 Mar 2014 02:25:30 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:22;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"358e2c672c30776704ad37f6205fe90d6e957dc3bea24759e2e05f6a86395eba";s:5:"title";s:19:"S02E20: Dynamic Duo";s:3:"url";s:54:"http://aroundthebloc.podbean.com/e/s02e20-dynamic-duo/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-26 00:01:54.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:787:"And then there were two. With most members of the team missing, the dynamic duo of Steve and Brendan bring you this week’s podcast which is more exciting than a backup goalie’s debut.
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/03/05/s02e21-la-banda-ing-together/</guid>
+		<description><![CDATA[<div>
+<div>A huge episode this week as two members of the RBB’s band, La Banda, join us to share their opinions on all the on and off the pitch happenings, which they drum into us, and are generally bass’d on their experiences in the RBB. Having been one of the cymbals of the active supporter group since day 1, they try not to repinique themselves as they recall how they formed, how the chants come together, and why they, for some reason, love Tom-Tomi Juric.</div>
+<div></div>
+<div>Also on the show……………………………………………….. thats right - the silent protest. We delve into the why, the who, what, when, the where and the how, as we were all grabbing our hair and tearing it out wondering what the hell was going on. </div>
+<div></div>
+<div>Sit back, relax and drop it like it’s hot - this is Around the Bloc</div>
+</div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for [...]</div>]]></description>
+			<content:encoded><![CDATA[<div>
+<div>A huge episode this week as two members of the RBB’s band, La Banda, join us to share their opinions on all the on and off the pitch happenings, which they drum into us, and are generally bass’d on their experiences in the RBB. Having been one of the cymbals of the active supporter group since day 1, they try not to repinique themselves as they recall how they formed, how the chants come together, and why they, for some reason, love Tom-Tomi Juric.</div>
+<div></div>
+<div>Also on the show……………………………………………….. thats right - the silent protest. We delve into the why, the who, what, when, the where and the how, as we were all grabbing our hair and tearing it out wondering what the hell was going on. </div>
+<div></div>
+<div>Sit back, relax and drop it like it’s hot - this is Around the Bloc</div>
+</div>
+<div></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:</div>
+<div>
+<div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e21-la-banda-ing-together/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/4b9fyv/S02E21_Around_the_Bloc_podcast.mp3" length="62748110" type="audio/mpeg"/>
+				<itunes:subtitle>A huge episode this week as two members of the RBB's band, La Banda, join us to share their opinions on all the on and ...</itunes:subtitle>
+		<itunes:summary>A huge episode this week as two members of the RBB's band, La Banda, join us to share their opinions on all the on and off the pitch happenings, which they drum into us, and are generally bass'd on their experiences in the RBB. Having been one of the cymbals of the active supporter group since day 1, they try not to repinique themselves as they recall how they formed, how the chants come together, and why they, for some reason, love Tom-Tomi Juric.Also on the show........................................................ thats right - the silent protest. We delve into the why, the who, what, when, the where and the how, as we were all grabbing our hair and tearing it out wondering what the hell was going on. Sit back, relax and drop it like it's hot - this is Around the BlocThanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:10:43</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E21: La Banda-ing Together</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:22;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"358e2c672c30776704ad37f6205fe90d6e957dc3bea24759e2e05f6a86395eba";s:5:"title";s:19:"S02E20: Dynamic Duo";s:3:"url";s:54:"http://aroundthebloc.podbean.com/e/s02e20-dynamic-duo/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-26 00:01:54.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:787:"And then there were two. With most members of the team missing, the dynamic duo of Steve and Brendan bring you this week’s podcast which is more exciting than a backup goalie’s debut.
 <br/>It was a perfect start to a long run of games for the Wanderers, and with the ACL looming, we turn our attention to the failings of Brisbane Roar and William Gallas. We give credit where credit’s due, though, to everyone’s favourite Wanderers player, Jerrad Tyson (as quoted in The Guardian), and our resident Spanish commentator has something special for him too.
 <br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>
 
-<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/x52pk9/S02E20_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/x52pk9/S02E20_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3983:"<item>
+		<title>S02E20: Dynamic Duo</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e20-dynamic-duo/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e20-dynamic-duo/#comments</comments>
+		<pubDate>Wed, 26 Feb 2014 00:01:54 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/02/26/s02e20-dynamic-duo/</guid>
+		<description><![CDATA[<div>And then there were two. With most members of the team missing, the dynamic duo of Steve and Brendan bring you this week’s podcast which is more exciting than a backup goalie’s debut.</div>
+<div><br /></div>
+<div>It was a perfect start to a long run of games for the Wanderers, and with the ACL looming, we turn our attention to the failings of Brisbane Roar and William Gallas. We give credit where credit’s due, though, to everyone’s favourite Wanderers player, Jerrad Tyson (as quoted in The Guardian), and our resident Spanish commentator has something special for him too.</div>
+<div><br /></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br /><div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;"></div>]]></description>
+			<content:encoded><![CDATA[<div>And then there were two. With most members of the team missing, the dynamic duo of Steve and Brendan bring you this week’s podcast which is more exciting than a backup goalie’s debut.</div>
+<div><br /></div>
+<div>It was a perfect start to a long run of games for the Wanderers, and with the ACL looming, we turn our attention to the failings of Brisbane Roar and William Gallas. We give credit where credit’s due, though, to everyone’s favourite Wanderers player, Jerrad Tyson (as quoted in The Guardian), and our resident Spanish commentator has something special for him too.</div>
+<div><br /></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br /><div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"><br /></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e20-dynamic-duo/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/x52pk9/S02E20_Around_the_Bloc_podcast.mp3" length="43763986" type="audio/mpeg"/>
+				<itunes:subtitle>And then there were two. With most members of the team missing, the dynamic duo of Steve and Brendan bring you this week's podcast which ...</itunes:subtitle>
+		<itunes:summary>And then there were two. With most members of the team missing, the dynamic duo of Steve and Brendan bring you this week's podcast which is more exciting than a backup goalie's debut.It was a perfect start to a long run of games for the Wanderers, and with the ACL looming, we turn our attention to the failings of Brisbane Roar and William Gallas. We give credit where credit's due, though, to everyone's favourite Wanderers player, Jerrad Tyson (as quoted in The Guardian), and our resident Spanish commentator has something special for him too.Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:31:10</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E20: Dynamic Duo</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:23;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"a530636c20c2e53edd2103ec481f9b78600c7a59473ab065b313462af25280f1";s:5:"title";s:16:"S02E19: Nameless";s:3:"url";s:51:"http://aroundthebloc.podbean.com/e/s02e19-nameless/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-19 01:22:59.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:722:"<p>With the Wanderers gameless, our podcast could’ve been aimless, if not for some questions which amazed us, sent through by listeners for a talkback segment that’s become famous, for rants and tangents and being totally outrageous and keeping Turner far from blameless. Our plugs are shameless, we hope listening will be painless as we try to offer you something different from the sameness and get to know you on a first name basis, and just like a really fat waitress we are Around the Bloc!
+</p><br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/hvru9y/S02E19_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3498:"<item>
+		<title>S02E19: Nameless</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e19-nameless/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e19-nameless/#comments</comments>
+		<pubDate>Wed, 19 Feb 2014 01:22:59 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:23;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"a530636c20c2e53edd2103ec481f9b78600c7a59473ab065b313462af25280f1";s:5:"title";s:16:"S02E19: Nameless";s:3:"url";s:51:"http://aroundthebloc.podbean.com/e/s02e19-nameless/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-19 01:22:59.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:722:"<p>With the Wanderers gameless, our podcast could’ve been aimless, if not for some questions which amazed us, sent through by listeners for a talkback segment that’s become famous, for rants and tangents and being totally outrageous and keeping Turner far from blameless. Our plugs are shameless, we hope listening will be painless as we try to offer you something different from the sameness and get to know you on a first name basis, and just like a really fat waitress we are Around the Bloc!
-</p><br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/hvru9y/S02E19_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:24;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"5cc34609174eae2b0c601d64998386f313c90be73957a9a0eb031bafd6770886";s:5:"title";s:16:"S02E18: En-Tyson";s:3:"url";s:51:"http://aroundthebloc.podbean.com/e/s02e18-en-tyson/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-12 01:04:12.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1035:"Everyones favourite Wanderers player, Jerrad Tyson, joins the ATB team for this week, and is a really good sport about getting bombarded with questions until late on a school night. 
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/02/19/s02e19-nameless/</guid>
+		<description><![CDATA[<p>With the Wanderers gameless, our podcast could’ve been aimless, if not for some questions which amazed us, sent through by listeners for a talkback segment that’s become famous, for rants and tangents and being totally outrageous and keeping Turner far from blameless. Our plugs are shameless, we hope listening will be painless as we try to offer you something different from the sameness and get to know you on a first name basis, and just like a really fat waitress we are Around the Bloc!
+</p><div><br /></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br /><div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+</div>
+]]></description>
+			<content:encoded><![CDATA[<p>With the Wanderers gameless, our podcast could’ve been aimless, if not for some questions which amazed us, sent through by listeners for a talkback segment that’s become famous, for rants and tangents and being totally outrageous and keeping Turner far from blameless. Our plugs are shameless, we hope listening will be painless as we try to offer you something different from the sameness and get to know you on a first name basis, and just like a really fat waitress we are Around the Bloc!
+</p><div><br /></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br /><div><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e19-nameless/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/hvru9y/S02E19_Around_the_Bloc_podcast.mp3" length="53332743" type="audio/mpeg"/>
+				<itunes:subtitle>With the Wanderers gameless, our podcast could've been aimless, if not for some questions which amazed us, sent through by listeners for a talkback segment ...</itunes:subtitle>
+		<itunes:summary>With the Wanderers gameless, our podcast could've been aimless, if not for some questions which amazed us, sent through by listeners for a talkback segment that's become famous, for rants and tangents and being totally outrageous and keeping Turner far from blameless. Our plugs are shameless, we hope listening will be painless as we try to offer you something different from the sameness and get to know you on a first name basis, and just like a really fat waitress we are Around the Bloc!Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:51:06</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E19: Nameless</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:24;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"5cc34609174eae2b0c601d64998386f313c90be73957a9a0eb031bafd6770886";s:5:"title";s:16:"S02E18: En-Tyson";s:3:"url";s:51:"http://aroundthebloc.podbean.com/e/s02e18-en-tyson/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-12 01:04:12.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:1035:"Everyones favourite Wanderers player, Jerrad Tyson, joins the ATB team for this week, and is a really good sport about getting bombarded with questions until late on a school night. 
 <br/>Berisha makes a nuisance of himself once again, so in the head to head between the Roar and the Wanderers this year, there’s been a 1-1, one team’s won one and one team’s won none. We find out who each podcasters mortal enemy is, Things We Could’ve Done Better Last Week almost makes a comeback, Jerrad offers some insight into the day to day dealings of a Wanderers player and has some handy hints for the relief of Fibromyalgia, whilst Turner, although you can’t hear it, does the exact opposite and polishes off an entire packet of chocolate snacks for the third week running. 
 <br/>This is Around the Bloc.
 
-<br/><p>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/></p><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/miea9s/S02E18_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:64:"
+<br/><p>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/></p><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/miea9s/S02E18_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4614:"<item>
+		<title>S02E18: En-Tyson</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e18-en-tyson/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e18-en-tyson/#comments</comments>
+		<pubDate>Wed, 12 Feb 2014 01:04:12 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:25;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"8cd5bd4644fe619055326755a580d8127a83d44c7dde325b55d858645c64891d";s:5:"title";s:25:"S02E17: Mid-Air Collision";s:3:"url";s:60:"http://aroundthebloc.podbean.com/e/s02e17-mid-air-collision/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-05 01:22:04.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:997:"Unlike the FFA, Around the Bloc does actually appreciate it’s fans, and this week we’ve rectified our premature evacuation of the podcast studio from last week and we’re back to our regular episode length. 
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/02/12/s02e18-en-tyson/</guid>
+		<description><![CDATA[<div>
+<div>Everyones favourite Wanderers player, Jerrad Tyson, joins the ATB team for this week, and is a really good sport about getting bombarded with questions until late on a school night. </div>
+<div><br /></div>
+<div>Berisha makes a nuisance of himself once again, so in the head to head between the Roar and the Wanderers this year, there’s been a 1-1, one team’s won one and one team’s won none. We find out who each podcasters mortal enemy is, Things We Could’ve Done Better Last Week almost makes a comeback, Jerrad offers some insight into the day to day dealings of a Wanderers player and has some handy hints for the relief of Fibromyalgia, whilst Turner, although you can’t hear it, does the exact opposite and polishes off an entire packet of chocolate snacks for the third week running. </div>
+<div><br /></div>
+<div>This is Around the Bloc.</div>
+</div>
+<div><br /></div>
+<p>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Chec [...]</p>]]></description>
+			<content:encoded><![CDATA[<div>
+<div>Everyones favourite Wanderers player, Jerrad Tyson, joins the ATB team for this week, and is a really good sport about getting bombarded with questions until late on a school night. </div>
+<div><br /></div>
+<div>Berisha makes a nuisance of himself once again, so in the head to head between the Roar and the Wanderers this year, there’s been a 1-1, one team’s won one and one team’s won none. We find out who each podcasters mortal enemy is, Things We Could’ve Done Better Last Week almost makes a comeback, Jerrad offers some insight into the day to day dealings of a Wanderers player and has some handy hints for the relief of Fibromyalgia, whilst Turner, although you can’t hear it, does the exact opposite and polishes off an entire packet of chocolate snacks for the third week running. </div>
+<div><br /></div>
+<div>This is Around the Bloc.</div>
+</div>
+<div><br /></div>
+<p>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br /></p><div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering" style="font-size:10pt;">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e18-en-tyson/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/miea9s/S02E18_Around_the_Bloc_podcast.mp3" length="54499476" type="audio/mpeg"/>
+				<itunes:subtitle>Everyones favourite Wanderers player, Jerrad Tyson, joins the ATB team for this week, and is a really good sport about getting bombarded with questions until ...</itunes:subtitle>
+		<itunes:summary>Everyones favourite Wanderers player, Jerrad Tyson, joins the ATB team for this week, and is a really good sport about getting bombarded with questions until late on a school night.Berisha makes a nuisance of himself once again, so in the head to head between the Roar and the Wanderers this year, there's been a 1-1, one team's won one and one team's won none. We find out who each podcasters mortal enemy is, Things We Could've Done Better Last Week almost makes a comeback, Jerrad offers some insight into the day to day dealings of a Wanderers player and has some handy hints for the relief of Fibromyalgia, whilst Turner, although you can't hear it, does the exact opposite and polishes off an entire packet of chocolate snacks for the third week running.This is Around the Bloc.Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords>football, soccer, ALeague, Western Sydney Wanderers, Australia</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:53:32</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E18: En-Tyson</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:25;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"8cd5bd4644fe619055326755a580d8127a83d44c7dde325b55d858645c64891d";s:5:"title";s:25:"S02E17: Mid-Air Collision";s:3:"url";s:60:"http://aroundthebloc.podbean.com/e/s02e17-mid-air-collision/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-02-05 01:22:04.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:997:"Unlike the FFA, Around the Bloc does actually appreciate it’s fans, and this week we’ve rectified our premature evacuation of the podcast studio from last week and we’re back to our regular episode length. 
 <br/>The Wanderers went up the Freeway to Newcastle, and after 2 amazing strikes and 2 dubious goals, came away with a point from a 2-all draw. Feeling more blue than a speech from Joel Griffiths, the RBB travelled to the W-League and National Youth League double header in modest numbers and were unfortunate not to see a point from those games. 
 <br/>The foreigners cop it in ATB Feedback this week, the ATB boys are left Mullen over the new signings, such as Antony Golec who is my new Wanderers brother, and Golgol who is Mehbratu.
 <br/>This is Around the Bloc.
-<br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/5cmzh/S02E17_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<br/>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br/><a href="http://www.facebook.com/cosykitchencatering" rel="noreferrer" target="_blank">facebook.com/cosykitchencatering</a>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/5cmzh/S02E17_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:4389:"<item>
+		<title>S02E17: Mid-Air Collision</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e17-mid-air-collision/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e17-mid-air-collision/#comments</comments>
+		<pubDate>Wed, 05 Feb 2014 01:22:04 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:26;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"8d5175a9ad7d391f64177552f41726b8018717b57883c0bd641330ff7c2da5ba";s:5:"title";s:28:"S02E16: Ingloryous Wanderers";s:3:"url";s:63:"http://aroundthebloc.podbean.com/e/s02e16-ingloryous-wanderers/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-29 01:45:41.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:771:"<p>Around the Bloc has a new sponsor this week in Cosy Kitchen Catering, but the feast they provided for us wasn’t the only one on offer as the Wanderers devoured Perth Glory in a 3-1 win at Parramatta Stadium. It was the Wanderers thyme to shine as they rocket-ed back into 2nd place, slowly eating away at the top spot. </p>
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/02/05/s02e17-mid-air-collision/</guid>
+		<description><![CDATA[<div>Unlike the FFA, Around the Bloc does actually appreciate it’s fans, and this week we’ve rectified our premature evacuation of the podcast studio from last week and we’re back to our regular episode length. </div>
+<div><br /></div>
+<div>The Wanderers went up the Freeway to Newcastle, and after 2 amazing strikes and 2 dubious goals, came away with a point from a 2-all draw. Feeling more blue than a speech from Joel Griffiths, the RBB travelled to the W-League and National Youth League double header in modest numbers and were unfortunate not to see a point from those games. </div>
+<div><br /></div>
+<div>The foreigners cop it in ATB Feedback this week, the ATB boys are left Mullen over the new signings, such as Antony Golec who is my new Wanderers brother, and Golgol who is Mehbratu.</div>
+<div><br /></div>
+<div>This is Around the Bloc.</div>
+<div><br /></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br /><a href=""></a></div>]]></description>
+			<content:encoded><![CDATA[<div>Unlike the FFA, Around the Bloc does actually appreciate it’s fans, and this week we’ve rectified our premature evacuation of the podcast studio from last week and we’re back to our regular episode length. </div>
+<div><br /></div>
+<div>The Wanderers went up the Freeway to Newcastle, and after 2 amazing strikes and 2 dubious goals, came away with a point from a 2-all draw. Feeling more blue than a speech from Joel Griffiths, the RBB travelled to the W-League and National Youth League double header in modest numbers and were unfortunate not to see a point from those games. </div>
+<div><br /></div>
+<div>The foreigners cop it in ATB Feedback this week, the ATB boys are left Mullen over the new signings, such as Antony Golec who is my new Wanderers brother, and Golgol who is Mehbratu.</div>
+<div><br /></div>
+<div>This is Around the Bloc.</div>
+<div><br /></div>
+<div>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:<br /><a href="http://www.facebook.com/cosykitchencatering" title="facebook.com/cosykitchencatering">facebook.com/cosykitchencatering</a></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e17-mid-air-collision/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/5cmzh/S02E17_Around_the_Bloc_podcast.mp3" length="50749965" type="audio/mpeg"/>
+				<itunes:subtitle>Unlike the FFA, Around the Bloc does actually appreciate it's fans, and this week we've rectified our premature evacuation of the podcast studio from last ...</itunes:subtitle>
+		<itunes:summary>Unlike the FFA, Around the Bloc does actually appreciate it's fans, and this week we've rectified our premature evacuation of the podcast studio from last week and we're back to our regular episode length.The Wanderers went up the Freeway to Newcastle, and after 2 amazing strikes and 2 dubious goals, came away with a point from a 2-all draw. Feeling more blue than a speech from Joel Griffiths, the RBB travelled to the W-League and National Youth League double header in modest numbers and were unfortunate not to see a point from those games.The foreigners cop it in ATB Feedback this week, the ATB boys are left Mullen over the new signings, such as Antony Golec who is my new Wanderers brother, and Golgol who is Mehbratu.This is Around the Bloc.Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at:facebook.com/cosykitchencatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:45:43</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E17: Mid-Air Collision</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:26;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"8d5175a9ad7d391f64177552f41726b8018717b57883c0bd641330ff7c2da5ba";s:5:"title";s:28:"S02E16: Ingloryous Wanderers";s:3:"url";s:63:"http://aroundthebloc.podbean.com/e/s02e16-ingloryous-wanderers/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-29 01:45:41.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:771:"<p>Around the Bloc has a new sponsor this week in Cosy Kitchen Catering, but the feast they provided for us wasn’t the only one on offer as the Wanderers devoured Perth Glory in a 3-1 win at Parramatta Stadium. It was the Wanderers thyme to shine as they rocket-ed back into 2nd place, slowly eating away at the top spot. </p>
 <p>ATBFeedback had Speccy all heated up this week, as he struggled to digest some of the answers provided, the Youth league boys had a win but the Roar proved Toum much for the Wanderers ladies up in Queensland. </p>
 <p>You can have your cake and eat it too, on this weeks episode of Around the Bloc. </p>
 <p>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at http://www.facebook.com/CosyKitchenCatering
-</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/rg46ga/S02E16_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/rg46ga/S02E16_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3684:"<item>
+		<title>S02E16: Ingloryous Wanderers</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e16-ingloryous-wanderers/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e16-ingloryous-wanderers/#comments</comments>
+		<pubDate>Wed, 29 Jan 2014 01:45:41 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:27;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"f225971b402e0c5bac7000d1520b4fc5846013aaa301f8723d3d3f0c3951d596";s:5:"title";s:24:"S02E15: Prodigal Podcast";s:3:"url";s:59:"http://aroundthebloc.podbean.com/e/s02e15-prodigal-podcast/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-22 00:49:59.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:702:"The Wanderers went to the City of Churches, praying for a win. Popa put a team on the pitch that had some fans asking ‘why have you forsaken me?’. And would you Adam-and-Eve it? We came away with another loss. It was the RBB’s tour of duty though, and the quality of the active support is a testament to the travelling fans. 
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/01/29/s02e16-ingloryous-wanderers/</guid>
+		<description><![CDATA[<p>Around the Bloc has a new sponsor this week in Cosy Kitchen Catering, but the feast they provided for us wasn’t the only one on offer as the Wanderers devoured Perth Glory in a 3-1 win at Parramatta Stadium. It was the Wanderers thyme to shine as they rocket-ed back into 2nd place, slowly eating away at the top spot. </p>
+<p>ATBFeedback had Speccy all heated up this week, as he struggled to digest some of the answers provided, the Youth league boys had a win but the Roar proved Toum much for the Wanderers ladies up in Queensland. </p>
+<p>You can have your cake and eat it too, on this weeks episode of Around the Bloc. </p>
+<p>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at http://www.facebook.com/CosyKitchenCatering
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>Around the Bloc has a new sponsor this week in Cosy Kitchen Catering, but the feast they provided for us wasn’t the only one on offer as the Wanderers devoured Perth Glory in a 3-1 win at Parramatta Stadium. It was the Wanderers thyme to shine as they rocket-ed back into 2nd place, slowly eating away at the top spot. </p>
+<p>ATBFeedback had Speccy all heated up this week, as he struggled to digest some of the answers provided, the Youth league boys had a win but the Roar proved Toum much for the Wanderers ladies up in Queensland. </p>
+<p>You can have your cake and eat it too, on this weeks episode of Around the Bloc. </p>
+<p>Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at http://www.facebook.com/CosyKitchenCatering
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e16-ingloryous-wanderers/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/rg46ga/S02E16_Around_the_Bloc_podcast.mp3" length="28714947" type="audio/mpeg"/>
+				<itunes:subtitle>Around the Bloc has a new sponsor this week in Cosy Kitchen Catering, but the feast they provided for us wasn't the only one on ...</itunes:subtitle>
+		<itunes:summary>Around the Bloc has a new sponsor this week in Cosy Kitchen Catering, but the feast they provided for us wasn't the only one on offer as the Wanderers devoured Perth Glory in a 3-1 win at Parramatta Stadium. It was the Wanderers thyme to shine as they rocket-ed back into 2nd place, slowly eating away at the top spot. 
+
+ATBFeedback had Speccy all heated up this week, as he struggled to digest some of the answers provided, the Youth league boys had a win but the Roar proved Toum much for the Wanderers ladies up in Queensland. 
+
+You can have your cake and eat it too, on this weeks episode of Around the Bloc. 
+
+Thanks to Cosy Kitchen Catering for sponsoring this weeks podcast! Check them out at http://www.facebook.com/CosyKitchenCatering</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>00:59:49</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E16: Ingloryous Wanderers</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:27;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"f225971b402e0c5bac7000d1520b4fc5846013aaa301f8723d3d3f0c3951d596";s:5:"title";s:24:"S02E15: Prodigal Podcast";s:3:"url";s:59:"http://aroundthebloc.podbean.com/e/s02e15-prodigal-podcast/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-22 00:49:59.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:702:"The Wanderers went to the City of Churches, praying for a win. Popa put a team on the pitch that had some fans asking ‘why have you forsaken me?’. And would you Adam-and-Eve it? We came away with another loss. It was the RBB’s tour of duty though, and the quality of the active support is a testament to the travelling fans. 
 <br/>In other news, Shinji Ono is leaving the club, unlikely to return in 3 days, the W-League and Youth League teams struggle through their matches, although neither are crucified as much as Speccy is when we confront him about his ‘Prodigal Son’ call from last week. 
 <br/>In the name of the Iván, the Turner, the Brendan and Steve, this is Around the Bloc.
-<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/udajt5/S02E15_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/udajt5/S02E15_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3846:"<item>
+		<title>S02E15: Prodigal Podcast</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e15-prodigal-podcast/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e15-prodigal-podcast/#comments</comments>
+		<pubDate>Wed, 22 Jan 2014 00:49:59 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/01/22/s02e15-prodigal-podcast/</guid>
+		<description><![CDATA[<div>The Wanderers went to the City of Churches, praying for a win. Popa put a team on the pitch that had some fans asking ‘why have you forsaken me?’. And would you Adam-and-Eve it? We came away with another loss. It was the RBB’s tour of duty though, and the quality of the active support is a testament to the travelling fans. </div>
+<div><br /></div>
+<div>In other news, Shinji Ono is leaving the club, unlikely to return in 3 days, the W-League and Youth League teams struggle through their matches, although neither are crucified as much as Speccy is when we confront him about his ‘Prodigal Son’ call from last week. </div>
+<div><br /></div>
+<div>In the name of the Iván, the Turner, the Brendan and Steve, this is Around the Bloc.</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"><br /></div>
+]]></description>
+			<content:encoded><![CDATA[<div>The Wanderers went to the City of Churches, praying for a win. Popa put a team on the pitch that had some fans asking ‘why have you forsaken me?’. And would you Adam-and-Eve it? We came away with another loss. It was the RBB’s tour of duty though, and the quality of the active support is a testament to the travelling fans. </div>
+<div><br /></div>
+<div>In other news, Shinji Ono is leaving the club, unlikely to return in 3 days, the W-League and Youth League teams struggle through their matches, although neither are crucified as much as Speccy is when we confront him about his ‘Prodigal Son’ call from last week. </div>
+<div><br /></div>
+<div>In the name of the Iván, the Turner, the Brendan and Steve, this is Around the Bloc.</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"><br /></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e15-prodigal-podcast/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/udajt5/S02E15_Around_the_Bloc_podcast.mp3" length="37385093" type="audio/mpeg"/>
+				<itunes:subtitle>The Wanderers went to the City of Churches, praying for a win. Popa put a team on the pitch that had some fans asking 'why ...</itunes:subtitle>
+		<itunes:summary>The Wanderers went to the City of Churches, praying for a win. Popa put a team on the pitch that had some fans asking 'why have you forsaken me?'. And would you Adam-and-Eve it? We came away with another loss. It was the RBB's tour of duty though, and the quality of the active support is a testament to the travelling fans.In other news, Shinji Ono is leaving the club, unlikely to return in 3 days, the W-League and Youth League teams struggle through their matches, although neither are crucified as much as Speccy is when we confront him about his 'Prodigal Son' call from last week.In the name of the Iván, the Turner, the Brendan and Steve, this is Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:17:52</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E15: Prodigal Podcast</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:28;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"0af60f8dfd83a91b8721387f3421e63cb20d57655be47a21b1fbc3b858de6714";s:5:"title";s:26:"S02E14: Two and a Half Men";s:3:"url";s:61:"http://aroundthebloc.podbean.com/e/s02e14-two-and-a-half-men/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-16 02:33:42.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:440:"Two and a half men present this week’s podcast, with a lineup more depleted than the Wanderers themselves, bringing you the mixed news from the last week. The Wanderers were the first team to win the Sydney Derby at home, but followed it up with a loss in Melbourne.
+<br/>ATBFeedback goes into overdrive, Speccy and JAR go overboard, transfer rumours are overhyped and we all get overtly stupid, in this week’s overtime Around The Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/hywpi9/S02E14_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:2783:"<item>
+		<title>S02E14: Two and a Half Men</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e14-two-and-a-half-men/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e14-two-and-a-half-men/#comments</comments>
+		<pubDate>Thu, 16 Jan 2014 02:33:42 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:28;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"0af60f8dfd83a91b8721387f3421e63cb20d57655be47a21b1fbc3b858de6714";s:5:"title";s:26:"S02E14: Two and a Half Men";s:3:"url";s:61:"http://aroundthebloc.podbean.com/e/s02e14-two-and-a-half-men/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-16 02:33:42.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:440:"Two and a half men present this week’s podcast, with a lineup more depleted than the Wanderers themselves, bringing you the mixed news from the last week. The Wanderers were the first team to win the Sydney Derby at home, but followed it up with a loss in Melbourne.
-<br/>ATBFeedback goes into overdrive, Speccy and JAR go overboard, transfer rumours are overhyped and we all get overtly stupid, in this week’s overtime Around The Bloc.";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/hywpi9/S02E14_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:29;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"6c408c42800416b22a33267fea943cf3fa9ab3a6ef83453f0436be3d01ed680d";s:5:"title";s:34:"S02E13: Nightmare on Melbs Streets";s:3:"url";s:69:"http://aroundthebloc.podbean.com/e/s02e13-nightmare-on-melbs-streets/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-08 00:46:26.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:581:"On Around the Bloc this week - Club in crisis, as Wellington are the first team to defeat the Wanderers at Parramatta in almost a year, and have now 1-3 in a row. 
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/01/16/s02e14-two-and-a-half-men/</guid>
+		<description><![CDATA[<div>Two and a half men present this week’s podcast, with a lineup more depleted than the Wanderers themselves, bringing you the mixed news from the last week. The Wanderers were the first team to win the Sydney Derby at home, but followed it up with a loss in Melbourne.</div>
+<div><br /></div>
+<div>ATBFeedback goes into overdrive, Speccy and JAR go overboard, transfer rumours are overhyped and we all get overtly stupid, in this week’s overtime Around The Bloc.</div>
+]]></description>
+			<content:encoded><![CDATA[<div>Two and a half men present this week’s podcast, with a lineup more depleted than the Wanderers themselves, bringing you the mixed news from the last week. The Wanderers were the first team to win the Sydney Derby at home, but followed it up with a loss in Melbourne.</div>
+<div><br /></div>
+<div>ATBFeedback goes into overdrive, Speccy and JAR go overboard, transfer rumours are overhyped and we all get overtly stupid, in this week’s overtime Around The Bloc.</div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e14-two-and-a-half-men/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/hywpi9/S02E14_Around_the_Bloc_podcast.mp3" length="60213605" type="audio/mpeg"/>
+				<itunes:subtitle>Two and a half men present this week's podcast, with a lineup more depleted than the Wanderers themselves, bringing you the mixed news from the ...</itunes:subtitle>
+		<itunes:summary>Two and a half men present this week's podcast, with a lineup more depleted than the Wanderers themselves, bringing you the mixed news from the last week. The Wanderers were the first team to win the Sydney Derby at home, but followed it up with a loss in Melbourne.ATBFeedback goes into overdrive, Speccy and JAR go overboard, transfer rumours are overhyped and we all get overtly stupid, in this week's overtime Around The Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:05:26</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E14: Two and a Half Men</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:29;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"6c408c42800416b22a33267fea943cf3fa9ab3a6ef83453f0436be3d01ed680d";s:5:"title";s:34:"S02E13: Nightmare on Melbs Streets";s:3:"url";s:69:"http://aroundthebloc.podbean.com/e/s02e13-nightmare-on-melbs-streets/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-08 00:46:26.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:581:"On Around the Bloc this week - Club in crisis, as Wellington are the first team to defeat the Wanderers at Parramatta in almost a year, and have now 1-3 in a row. 
 <br/>The pressing issue this week, though, is the suspended sentences placed on Western Sydney and the Melbourne Victory over the events that took place before and during their last game. The team discuss their views and one ATB member gets all ‘tin-foil-hat’ about it. 
 <br/>We review the upcoming Sydney Derby, offer the worst football tips on the planet, and much more on this edition of Around the Bloc.
-<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/dsye4n/S02E13_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/dsye4n/S02E13_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3556:"<item>
+		<title>S02E13: Nightmare on Melbs Streets</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e13-nightmare-on-melbs-streets/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e13-nightmare-on-melbs-streets/#comments</comments>
+		<pubDate>Wed, 08 Jan 2014 00:46:26 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:30;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"47f92bf67ab76489f430d9d2cbc26fbc6c564b90198ef72fd935ae00f3928c06";s:5:"title";s:20:"S02E12: The Hangover";s:3:"url";s:55:"http://aroundthebloc.podbean.com/e/s02e12-the-hangover/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-02 03:05:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:714:"<p>Fireworks, this week, as the ATB boys
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/01/08/s02e13-nightmare-on-melbs-streets/</guid>
+		<description><![CDATA[<div>On Around the Bloc this week - Club in crisis, as Wellington are the first team to defeat the Wanderers at Parramatta in almost a year, and have now 1-3 in a row. </div>
+<div><br /></div>
+<div>The pressing issue this week, though, is the suspended sentences placed on Western Sydney and the Melbourne Victory over the events that took place before and during their last game. The team discuss their views and one ATB member gets all ‘tin-foil-hat’ about it. </div>
+<div><br /></div>
+<div>We review the upcoming Sydney Derby, offer the worst football tips on the planet, and much more on this edition of Around the Bloc.</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"><br /></div>
+]]></description>
+			<content:encoded><![CDATA[<div>On Around the Bloc this week - Club in crisis, as Wellington are the first team to defeat the Wanderers at Parramatta in almost a year, and have now 1-3 in a row. </div>
+<div><br /></div>
+<div>The pressing issue this week, though, is the suspended sentences placed on Western Sydney and the Melbourne Victory over the events that took place before and during their last game. The team discuss their views and one ATB member gets all ‘tin-foil-hat’ about it. </div>
+<div><br /></div>
+<div>We review the upcoming Sydney Derby, offer the worst football tips on the planet, and much more on this edition of Around the Bloc.</div>
+<div style="font-family:Arial, Verdana;font-size:10pt;font-style:normal;font-variant:normal;font-weight:normal;line-height:normal;"><br /></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e13-nightmare-on-melbs-streets/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/dsye4n/S02E13_Around_the_Bloc_podcast.mp3" length="43588025" type="audio/mpeg"/>
+				<itunes:subtitle>On Around the Bloc this week - Club in crisis, as Wellington are the first team to defeat the Wanderers at Parramatta in almost a ...</itunes:subtitle>
+		<itunes:summary>On Around the Bloc this week - Club in crisis, as Wellington are the first team to defeat the Wanderers at Parramatta in almost a year, and have now 1-3 in a row.The pressing issue this week, though, is the suspended sentences placed on Western Sydney and the Melbourne Victory over the events that took place before and during their last game. The team discuss their views and one ATB member gets all 'tin-foil-hat' about it.We review the upcoming Sydney Derby, offer the worst football tips on the planet, and much more on this edition of Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:30:48</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E13: Nightmare on Melbs Streets</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:30;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"47f92bf67ab76489f430d9d2cbc26fbc6c564b90198ef72fd935ae00f3928c06";s:5:"title";s:20:"S02E12: The Hangover";s:3:"url";s:55:"http://aroundthebloc.podbean.com/e/s02e12-the-hangover/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-01-02 03:05:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:714:"<p>Fireworks, this week, as the ATB boys
 leave their luxurious holiday homes to once again bung on about the Wanderers
 in the first podcast of the new year. We showed sparkle and flare to beat the
 Mariners, were disappointed at what seemed like a minute after midnight in
@@ -719,404 +1118,552 @@ hear many different stories from Wanderers away trips, straight from the horse�
 mouths, and all the usual stuff is in there too.</p>
 
 <p>Finally, Happy New Year to all of our
-listeners. This is Around The Bloc.</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/673jx/Around_The_Bloc_podcast_S02E12.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
+listeners. This is Around The Bloc.</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/673jx/Around_The_Bloc_podcast_S02E12.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3910:"<item>
+		<title>S02E12: The Hangover</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e12-the-hangover/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e12-the-hangover/#comments</comments>
+		<pubDate>Thu, 02 Jan 2014 03:05:02 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2014/01/02/s02e12-the-hangover/</guid>
+		<description><![CDATA[<p class="MsoNormal" style="margin-bottom:.0001pt;">Fireworks, this week, as the ATB boys
+leave their luxurious holiday homes to once again bung on about the Wanderers
+in the first podcast of the new year. We showed sparkle and flare to beat the
+Mariners, were disappointed at what seemed like a minute after midnight in
+Melbourne, and Wellington were 2 hours AND 2 goals ahead of us, although we
+didn’t know that at the time of recording so you can still hear the gleeful
+optimism in our voices.</p>
+<p class="MsoNormal" style="margin-bottom:.0001pt;">#ATBFeedback goes live this week and we
+hear many different stories from Wanderers away trips, straight from the horse’s
+mouths, and all the usual stuff is in there too.</p>
+<p class="MsoNormal" style="margin-bottom:.0001pt;"></p><p></p>
+<p class="MsoNormal" style="margin-bottom:.0001pt;">Finally, Happy New Year to all of our
+listeners. This is Around The Bloc.</p>
+
+]]></description>
+			<content:encoded><![CDATA[<p class="MsoNormal" style="margin-bottom:.0001pt;">Fireworks, this week, as the ATB boys
+leave their luxurious holiday homes to once again bung on about the Wanderers
+in the first podcast of the new year. We showed sparkle and flare to beat the
+Mariners, were disappointed at what seemed like a minute after midnight in
+Melbourne, and Wellington were 2 hours AND 2 goals ahead of us, although we
+didn’t know that at the time of recording so you can still hear the gleeful
+optimism in our voices.</p>
+<p class="MsoNormal" style="margin-bottom:.0001pt;">#ATBFeedback goes live this week and we
+hear many different stories from Wanderers away trips, straight from the horse’s
+mouths, and all the usual stuff is in there too.</p>
+<p class="MsoNormal" style="margin-bottom:.0001pt;"></p><p></p>
+<p class="MsoNormal" style="margin-bottom:.0001pt;">Finally, Happy New Year to all of our
+listeners. This is Around The Bloc.</p>
+
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e12-the-hangover/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/673jx/Around_The_Bloc_podcast_S02E12.mp3" length="39616577" type="audio/mpeg"/>
+				<itunes:subtitle>Fireworks, this week, as the ATB boys
+leave their luxurious holiday homes to once again bung on about the Wanderers
+in the first podcast of the new ...</itunes:subtitle>
+		<itunes:summary>Fireworks, this week, as the ATB boys
+leave their luxurious holiday homes to once again bung on about the Wanderers
+in the first podcast of the new year. We showed sparkle and flare to beat the
+Mariners, were disappointed at what seemed like a minute after midnight in
+Melbourne, and Wellington were 2 hours AND 2 goals ahead of us, although we
+didn't know that at the time of recording so you can still hear the gleeful
+optimism in our voices.#ATBFeedback goes live this week and we
+hear many different stories from Wanderers away trips, straight from the horse’s
+mouths, and all the usual stuff is in there too.
+
+Finally, Happy New Year to all of our
+listeners. This is Around The Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:22:31</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E12: The Hangover</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:31;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"d1f0fd26c1fcd19bddc3a514855222547f0282cdad90d69e08f80703f78e37df";s:5:"title";s:22:"S02E11: Three Wise Men";s:3:"url";s:57:"http://aroundthebloc.podbean.com/e/s02e11-three-wise-men/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-12-18 01:37:51.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:619:"The RBB followed their stars up the road for anything but a silent night in Newcastle. On this week’s podcast, three wise men discuss whether Mark Bridge’s goal was the result of a push in the back, or an immaculate deflection off Haliti’s head, if Birighitti should have been told ‘theres no more room at the inn’, and how the little drummer boy broke his instrument. 
+<br/>In other news, Perth do away with their man(a)ger, ATBFeedback turns into a celebratory feast and the W-League team goes on their merry way to record a win against the Glory. All this and more on this weeks edition of Around the Bloc.";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/ccb6x/S02E11_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3292:"<item>
+		<title>S02E11: Three Wise Men</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e11-three-wise-men/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e11-three-wise-men/#comments</comments>
+		<pubDate>Wed, 18 Dec 2013 01:37:51 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
 		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:31;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"d1f0fd26c1fcd19bddc3a514855222547f0282cdad90d69e08f80703f78e37df";s:5:"title";s:22:"S02E11: Three Wise Men";s:3:"url";s:57:"http://aroundthebloc.podbean.com/e/s02e11-three-wise-men/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-12-18 01:37:51.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:619:"The RBB followed their stars up the road for anything but a silent night in Newcastle. On this week’s podcast, three wise men discuss whether Mark Bridge’s goal was the result of a push in the back, or an immaculate deflection off Haliti’s head, if Birighitti should have been told ‘theres no more room at the inn’, and how the little drummer boy broke his instrument. 
-<br/>In other news, Perth do away with their man(a)ger, ATBFeedback turns into a celebratory feast and the W-League team goes on their merry way to record a win against the Glory. All this and more on this weeks edition of Around the Bloc.";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/ccb6x/S02E11_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:32;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"ebc093f2132d1f822e22359645429cc8c090c3558dd10623053d3133864ecc0a";s:5:"title";s:22:"S02E10: Drawn Together";s:3:"url";s:57:"http://aroundthebloc.podbean.com/e/s02e10-drawn-together/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-12-11 01:23:28.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:514:"This week - The Asian Champions League draw is announced, during which the Wanderers will be China win to progress through the group stages and create Korea highlights for themselves, and if they succeed, Japandamonium will ensue. 
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/12/18/s02e11-three-wise-men/</guid>
+		<description><![CDATA[<div>The RBB followed their stars up the road for anything but a silent night in Newcastle. On this week’s podcast, three wise men discuss whether Mark Bridge’s goal was the result of a push in the back, or an immaculate deflection off Haliti’s head, if Birighitti should have been told ‘theres no more room at the inn’, and how the little drummer boy broke his instrument. </div>
+<div><br /></div>
+<div>In other news, Perth do away with their man(a)ger, ATBFeedback turns into a celebratory feast and the W-League team goes on their merry way to record a win against the Glory. All this and more on this weeks edition of Around the Bloc. </div>
+]]></description>
+			<content:encoded><![CDATA[<div>The RBB followed their stars up the road for anything but a silent night in Newcastle. On this week’s podcast, three wise men discuss whether Mark Bridge’s goal was the result of a push in the back, or an immaculate deflection off Haliti’s head, if Birighitti should have been told ‘theres no more room at the inn’, and how the little drummer boy broke his instrument. </div>
+<div><br /></div>
+<div>In other news, Perth do away with their man(a)ger, ATBFeedback turns into a celebratory feast and the W-League team goes on their merry way to record a win against the Glory. All this and more on this weeks edition of Around the Bloc. </div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e11-three-wise-men/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/ccb6x/S02E11_Around_the_Bloc_podcast.mp3" length="47449341" type="audio/mpeg"/>
+				<itunes:subtitle>The RBB followed their stars up the road for anything but a silent night in Newcastle. On this week's podcast, three wise men discuss whether ...</itunes:subtitle>
+		<itunes:summary>The RBB followed their stars up the road for anything but a silent night in Newcastle. On this week's podcast, three wise men discuss whether Mark Bridge's goal was the result of a push in the back, or an immaculate deflection off Haliti's head, if Birighitti should have been told 'theres no more room at the inn', and how the little drummer boy broke his instrument.In other news, Perth do away with their man(a)ger, ATBFeedback turns into a celebratory feast and the W-League team goes on their merry way to record a win against the Glory. All this and more on this weeks edition of Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:38:51</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E11: Three Wise Men</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:32;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"ebc093f2132d1f822e22359645429cc8c090c3558dd10623053d3133864ecc0a";s:5:"title";s:22:"S02E10: Drawn Together";s:3:"url";s:57:"http://aroundthebloc.podbean.com/e/s02e10-drawn-together/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-12-11 01:23:28.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:514:"This week - The Asian Champions League draw is announced, during which the Wanderers will be China win to progress through the group stages and create Korea highlights for themselves, and if they succeed, Japandamonium will ensue. 
 <br/>In the meantime however, the club falls deeper into crisis as they go yet another game without a win and add another draw to their streak. Will they be able to break it against the relentlessness of the Newcastle Jets? 
-<br/>All this and more on this edition of Around the Bloc";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/7gn4p/S02E10_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:33;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"ab8415ae2f421422b1a3063470ff6719e4d3554bd37b624a74ee12a1ab2a330d";s:5:"title";s:24:"S02E09: Club in Crisis!!";s:3:"url";s:57:"http://aroundthebloc.podbean.com/e/s02e09-club-in-crisis/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-12-04 03:22:19.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:583:"<p>It’s episode 9 this week, and that means we’re one third of the way through the season. The Wanderers played a pretty boring nil-all draw on the weekend, and as a result, just like the team we’re playing next week, we all lose our Kewell. Our resident Spanish Commentator makes his return, but with nothing to commentate on we turn our attention to squad rotation and whether or not it’s a good thing. Speaking of going around in circles, the rest of the podcast includes W-League, Youth League, an “International wrap up”, and more. This is Around the Bloc. <br/></p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/g8hhht/S02E09_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:34;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"89cded3f6ce98c6dafceb1fb3c5f6403cc1dc88ca57096137677a4faf00e9d4a";s:5:"title";s:38:"S02E08: Scrappy Curtains with Pancakes";s:3:"url";s:73:"http://aroundthebloc.podbean.com/e/s02e08-scrappy-curtains-with-pancakes/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-27 01:05:32.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:624:"<p>Around the Bloc returns for another week and, like Brisbane Roar, is only good for about 20 minutes, but still does enough to see out a full hour and a half. Turner, our resident caped crusader, tells us what he remembers of his antics from the away trip whilst Brendan makes one too many trips to Marconi. The boys finally get to dissect a loss but, with the help of <a href="https://www.facebook.com/hashtag/atbfeedback" rel="noreferrer" target="_blank">#ATBFeedback</a>, are able to see the positives. There’s good news for the Youth League, segues galore, and much much more on this edition of Around the Bloc.
-</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/jjv4rf/S02E08_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:35;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"95d652c913366832bd26c6bc9f9d16da762a8a481939afa7c637338b263f1757";s:5:"title";s:27:"S02E07: Reigning at the Top";s:3:"url";s:62:"http://aroundthebloc.podbean.com/e/s02e07-reigning-at-the-top/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-20 00:45:16.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:703:"<p>It was wet, wet, wet in Parramatta on Saturday night, but the love was certainly not all around in the stadium, with the two arguably biggest and most passionate groups of fans in the A-League battling it out in the stands. It was 82 minutes before Mark Bridge put away the winner, and less than 24 hours later the Wanderers finished the round at the top of the table for the first time this season. The bliss turns to diss in ATBFeedback, the joy for the Wanderers unfortunately stopped short of the W-League and Youth League games, and the Newcastle Jets and Michael Turner both pull off upsets over their opponents in the same game. All this and much more on this edition of Around The Bloc. 
-</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/nnfgj8/S02E07_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:36;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"bfe8d7e67b45fed021accd333968663f9c04862fea60f7877377b7bde770b290";s:5:"title";s:17:"S02E06: Heartbeat";s:3:"url";s:52:"http://aroundthebloc.podbean.com/e/s02e06-heartbeat/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-13 00:15:01.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:714:"On the day Santalab showed his loyalty to the Wanderers like a Golden Lab to a blind man, the ATB boys are back with another episode more chockers than Parramatta Stadium will be on Saturday night. After a gritty 1-0 win where Cole scored in the cold, TomiGun should’ve kept the safety on and the team had the Heart beat, we look forward to victory over the Victory both on and off the pitch. Cop Watch returns in comical fashion, we report on the start of the W-League and the women and youth teams double header, which was the second one of the weekend after Seb Ryall’s goal from the Big Blue. All this and much more on this edition of Around The Bloc. 
-<br/>Oh…and we interview Foxsport’s Adam Peacock.";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/w4vw3/S02E06_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:37;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"5009b50603a446b32272bec2dd4b0d9526797253818d3a47b4252ed7a9975780";s:5:"title";s:38:"S02E05: Receipt, Deceit, but no Defeat";s:3:"url";s:71:"http://aroundthebloc.podbean.com/e/s02e05-receipt-deceit-but-no-defeat/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-06 03:43:33.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:639:"<p>With Speccy benched, ATB is down to 4 men this week. TomiGun© put 2 away at home against the Reds whilst Polenz was lucky that only Adelaide’s secondary kit colour featured amongst the cards shown to him on Friday night. Cop Watch is back, unfortunately, due to fear of a receipt roll planet, and ATBTalkback reveals the pep talks that Wanderers fans would use to pump up the team. Finally, the W-League returns with a double header featuring the WanderWomen and the WanderKids of the National Youth League at Marconi, and the ATB tipping comp receives a shake up. All this and more, on this week’s edition of Around the Bloc.
-</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/cxfuam/S02E05_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:38;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"7b2fad97ff41c9b417d947c5148fcc0bb244f4421500dc97fcb9429a2476d6ab";s:5:"title";s:41:"S02E04: A better love story than Twilight";s:3:"url";s:76:"http://aroundthebloc.podbean.com/e/s02e04-a-better-love-story-than-twilight/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-30 01:04:54.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:683:"<p>Around the Bloc has a special announcement - this week, we talk about football! The beautiful game is back in the spotlight as the Wanderers defeat Sydney FC in the first Derby D’Sydney of the season. Speccy turned up, Brendan was there too but… also kind of wasn’t, Ivan revelled in the cool, fresh air (for most of the night), Turner made the papers again and Stephen got to make fun of everyone for all of the above. Aside from a few exceptions, the Police and media were generally well-behaved.<br/>We find out what rituals different Wanderers fans have pre-game in ATBTalkback and preview our first game to be aired live, on free-to-air TV against Adelaide United.
-</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/wjeiq5/S02E04_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:39;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"dc933486dcb16368f6cb66f2f4d0dcb8a437ba6ad216b40454edcf7cf2c9ab92";s:5:"title";s:32:"S02E03: To the left, to the left";s:3:"url";s:66:"http://aroundthebloc.podbean.com/e/s02e03-to-the-left-to-the-left/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-23 00:36:44.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:686:"<p>Football is, for once, the minor topic on this week’s podcast, as we are unfortunately forced to turn our attention to towards the over handed approach the authorities are taking towards Western Sydney’s football fans. Ivan interviews Chadi (a Defence Attorney), Danielle (whose relatives were victims of these tactics), and none other than Lyall Gorman, Wanderers CEO, to get their opinions on what is fast becoming the biggest issue we are facing when supporting our sport.</p>
-<p>On a lighter note, we DO actually talk about football, with the 1-1 against Wellington last week, and the Derby D’Sydney coming up, and Nick Nova’s ‘Do You Even Dale?’ makes its debut.</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/vqtbpc/S02E03_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:40;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"a6a23d90ea8c5165a8029d9aa86dec6285c68000bbf43c3d5db0483fafd48571";s:5:"title";s:19:"S02E02: Say Cheese!";s:3:"url";s:53:"http://aroundthebloc.podbean.com/e/s02e02-say-cheese/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-16 01:19:39.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:310:"<p>The team get together this week and discuss issues such as the RBB becoming the new stars of ‘Australia’s funniest home surveillance videos’, all the news from the latest Wanderers fan forum, a preview of our first home game of the season and much more, on this edition of Around the Bloc…</p>
-<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/ncxtdb/S02E02_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:41;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"3a1608c23c152ba35d07ea731117aa0595037b863dce10e73c0b8f63204f889a";s:5:"title";s:35:"S02E01: The Difficult Second Season";s:3:"url";s:70:"http://aroundthebloc.podbean.com/e/s02e01-the-difficult-second-season/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-09 05:23:27.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:379:"<p>The Around the Bloc team take our seats once more for another exciting year of banter as we attempt to defend our Podcast D’Or award.</p>
-<p>On this weeks episode we talk A-League, W-League, Youth League and Powerchair League, get an update on those schnitzel rolls from Campbelltown Stadium, discuss the ins, outs, ups and downs of the off season and much much more… </p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/hjuu3c/S02E01_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-				
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:42;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"400c94b0f101c91f83d45b38af45b6289d36a02a5f8ea36c29ccf82a42a00b9a";s:5:"title";s:31:"Episode 24: Grand Final relapse";s:3:"url";s:66:"http://aroundthebloc.podbean.com/e/episode-24-grand-final-relapse/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-25 08:54:57.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:616:"<p>In the season finale JAR, Speccy, Turner &amp; Erebus grieve together over the grand final loss but fondly look back at the Wanderers’ very successful first season. We discuss season highlights in #ATBTalkback and recap the parade in Parramatta and the WSW awards night. Thanks to all our listeners and contributors over the season and we’ll be back next season bigger and better! Check us out on twitter - <a href="http://twitter.com/ATBWSW" rel="noreferrer" target="_blank">@ATBWSW</a> - or <a href="http://www.facebook.com/AroundTheBloc" rel="noreferrer" target="_blank">facebook.com/AroundTheBloc</a>
-</p>";s:13:"enclosure_url";s:80:"http://aroundthebloc.podbean.com/mf/feed/z5umt/Around_the_Bloc_podcast_ep024.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:43;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"039cdc6ba289e62ff83bbe7becd07a37dc0913d05335b76938040968217e8bd7";s:5:"title";s:32:"Episode 23: Stadium Wide Pozcast";s:3:"url";s:67:"http://aroundthebloc.podbean.com/e/episode-23-stadium-wide-pozcast/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-18 02:27:18.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:331:"<p>JAR, Speccy, Turner &amp; Erebus talk about two of the most important games in our clubs history - the Semi Final against Brisbane Roar, and the impending Grand Final against Central Coast Mariners. #ATBTalkback returns and actually kind of works this time. Check us out on twitter - @ATBWSW - or facebook.com/AroundTheBloc
-</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/5u3u83/Around_the_bloc_podcast_ep023.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:44;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"58b057fab6eb2f643ef9d5962d1c42961a97001ffa27c5f18446d3cde920aaa4";s:5:"title";s:53:"Episode 22: Wait a minute? You Guys didn’t play?!?!";s:3:"url";s:80:"http://aroundthebloc.podbean.com/e/episode-22-wait-a-minute-you-guys-didnt-play/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-11 01:18:29.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:637:"<p>FFDU Nominated Finalist; Around the Bloc are joined by Erebus, JAR, Turner &amp; Speccy as they smash through a quick episode (for our standards) discussing the sudden death finals that have happened over the weekend, the upcoming semi final against Brisbane which has got everyone talking! Listen in for details regarding the march, our predictions, Speccy finally winning ‘guess a player’ segment to bring Erebus’ winning streak to an end and our resident Latin correspondent; Pistola giving us an indepth interview! Follow us on twitter ‘@ATBWSW’, like us on Facebook; ‘Around the Bloc’ and subscribe via iTunes!
-</p>";s:13:"enclosure_url";s:80:"http://aroundthebloc.podbean.com/mf/feed/n3dme/Around_the_bloc_podcast_ep022.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:45;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"371ae51388bc263cf23a0f85d646e62f9b46c08762272a35af26d8781a9e358f";s:5:"title";s:46:"Episode 21: Campeone, Campeone, Ole, Ole, Ole!";s:3:"url";s:76:"http://aroundthebloc.podbean.com/e/episode-21-campeone-campeone-ole-ole-ole/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-04 03:27:32.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:677:"<p>Speccy returns and joins JAR, Erebus and a slightly inebriated Turner to discuss and celebrate the Wanderers winning the premiership in their first year as a football club. The release date of this podcast, April 4th, 2013, also happens to be the Wanderers first birthday (i.e. 1 year since the PM announced that it would be happening). A lot has happened since then, but despite the length of the podcast, not all of it is discussed as we stick to the most important parts of the last week. The team recorded on the day of the Newcastle game and that audio is included too. Also: ATB Talkback, Spanish Commentary from Pistola and more. Check us out on twitter @ATBWSW.
-</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/ypjrdm/Around_the_bloc_podcast_ep021.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:46;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"078fb324759d5bbc9ca5db3f2323fa13ee25909ebabaaabc2901fa8d78a4d0ea";s:5:"title";s:21:"Episode 20: Milestone";s:3:"url";s:56:"http://aroundthebloc.podbean.com/e/episode-20-milestone/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-28 01:41:45.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:650:"<p>In the absence of Speccy once again, JAR, Erebus and Turner discuss football, and realise they are the only ‘media’ outlet in Sydney doing so this week. The actual match that was played between the Wanderers and Sydney FC is discussed, as opposed to off-field incident’s which everyone is sick of hearing about, along with everyones chances of making the finals (which admittedly gets a bit confusing), the transport and the RBBQ before the last regular season game in Newcastle, and turners infamous ‘Who Am I?’ segment gets another run. TWCDBLW possibly meets it’s untimely demise too. Check out www.twitter.com/ATBWSW for more.
-</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/x2bb3k/Around_the_bloc_podcast_ep020.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:47;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"84a919d97cd1f33ae8357fd99ace2c8ab2d7fe9101536f2d94ced27b797cb0a7";s:5:"title";s:38:"Episode 19: And Then There Were Two…";s:3:"url";s:70:"http://aroundthebloc.podbean.com/e/episode-19-and-then-there-were-two/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-21 03:52:37.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:458:"<p>JAR and Turner are left to their own devices by an absent Speccy and Erebus and quite frankly, they control the ship just nicely. The dynamic duo cut a boosegump inducing promo for the upcoming derby, discuss the Heart game and the infamous ‘incident’ that occurred. Dicko has his say about that too. Details for the FFDU awards, the Newcastle RBBBBBQB and #ATBTalkback also feature in this episode. Check out www.westsydneyfootball.com for more.
-</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/w8qsxz/Around_the_bloc_podcast_ep019.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:64:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-		
-		";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:48;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"0c58ecb9d07513d17fdfcdfb596507bc7aaa35186bee19f534cb12b3e94dccd5";s:5:"title";s:52:"Episode 18: Seriously this time… Back to our Roots";s:3:"url";s:84:"http://aroundthebloc.podbean.com/e/episode-18-seriously-this-time-back-to-our-roots/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-14 05:30:11.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:359:"<p>JAR, Speccy, Turner and Erebus grab the constructive criticism received through the week by the horns and go back to what they do best. The infamous silent protest is covered along with the game against Wellington, the upcoming game against Heart, the tickets given to underprivileged kids and much more. Check out www.westsydneyfootball.com for more.
-</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/4thrnf/Around_the_bloc_podcast_ep018.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:49;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"04394c9ec5c3e540e4050ab9ec295165ab182541074e2c0eb33aafc6d6db6a8b";s:5:"title";s:34:"Episode 17: Live From the JERRcave";s:3:"url";s:69:"http://aroundthebloc.podbean.com/e/episode-17-live-from-the-jerrcave/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-07 04:57:39.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:700:"<p>JAR, Speccy, Turner and Erebus rock up to Jerrad, Joey and Tahj’s pad for a game of UNO and a podcast ensues. The Wanderers winning against Mariners and going top of the league, the upcoming game against Wellington, an ‘in-the-making’ documentary about the Wanderers and the RBB and the recent charity work that has seen some underprivileged community groups receive tickets to the Nix game are all discussed. As it stands, JJ &amp; T are up 2-0 in the FIFA 13 stakes, comfortably defeating the team of JAR and two blokes who don’t know how to play FIFA in two games. Follow us on twitter @ABTWSF or www.facebook.com/aroundthebloc . Also check out www.westsydneyfootball.com for more.
-</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/tynye6/Around_the_bloc_podcast_ep017.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:63:"
-		
-		
-		
-		
-		
-		
-	
-		
-		
-			
-			
-			
-				
-		
-		
-		
-		
-		
-				";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}}s:2:"id";s:33:"http://aroundthebloc.podbean.com/";s:5:"title";s:15:"Around the Bloc";s:11:"description";s:169:"The Official Supporters Podcast of the Western Sydney Wanderers. www.aroundthebloc.com.au Now on iTunes - https://itunes.apple.com/au/podcast/around-the-bloc/id581817326";s:8:"feed_url";s:0:"";s:8:"site_url";s:33:"http://aroundthebloc.podbean.com/";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-16 12:56:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:8:"language";s:2:"en";s:4:"logo";s:72:"http://imglogo.podbean.com/image-logo/586645/ATBLogo-BlackBackground.png";s:4:"icon";s:0:"";}
+<br/>All this and more on this edition of Around the Bloc";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/7gn4p/S02E10_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3468:"<item>
+		<title>S02E10: Drawn Together</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e10-drawn-together/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e10-drawn-together/#comments</comments>
+		<pubDate>Wed, 11 Dec 2013 01:23:28 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/12/11/s02e10-drawn-together/</guid>
+		<description><![CDATA[<div><font face="Arial, Verdana" size="2">This week - The Asian Champions League draw is announced, during which the Wanderers will be China win to progress through the group stages and create Korea highlights for themselves, and if they succeed, Japandamonium will ensue. </font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">In the meantime however, the club falls deeper into crisis as they go yet another game without a win and add another draw to their streak. Will they be able to break it against the relentlessness of the Newcastle Jets? </font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">All this and more on this edition of Around the Bloc</font></div>
+]]></description>
+			<content:encoded><![CDATA[<div><font face="Arial, Verdana" size="2">This week - The Asian Champions League draw is announced, during which the Wanderers will be China win to progress through the group stages and create Korea highlights for themselves, and if they succeed, Japandamonium will ensue. </font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">In the meantime however, the club falls deeper into crisis as they go yet another game without a win and add another draw to their streak. Will they be able to break it against the relentlessness of the Newcastle Jets? </font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">All this and more on this edition of Around the Bloc</font></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e10-drawn-together/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/7gn4p/S02E10_Around_the_Bloc_podcast.mp3" length="32754732" type="audio/mpeg"/>
+				<itunes:subtitle>This week - The Asian Champions League draw is announced, during which the Wanderers will be China win to progress through the group stages and ...</itunes:subtitle>
+		<itunes:summary>This week - The Asian Champions League draw is announced, during which the Wanderers will be China win to progress through the group stages and create Korea highlights for themselves, and if they succeed, Japandamonium will ensue.In the meantime however, the club falls deeper into crisis as they go yet another game without a win and add another draw to their streak. Will they be able to break it against the relentlessness of the Newcastle Jets?All this and more on this edition of Around the Bloc</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:08:14</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E10: Drawn Together</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:33;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"ab8415ae2f421422b1a3063470ff6719e4d3554bd37b624a74ee12a1ab2a330d";s:5:"title";s:24:"S02E09: Club in Crisis!!";s:3:"url";s:57:"http://aroundthebloc.podbean.com/e/s02e09-club-in-crisis/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-12-04 03:22:19.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:583:"<p>It’s episode 9 this week, and that means we’re one third of the way through the season. The Wanderers played a pretty boring nil-all draw on the weekend, and as a result, just like the team we’re playing next week, we all lose our Kewell. Our resident Spanish Commentator makes his return, but with nothing to commentate on we turn our attention to squad rotation and whether or not it’s a good thing. Speaking of going around in circles, the rest of the podcast includes W-League, Youth League, an “International wrap up”, and more. This is Around the Bloc. <br/></p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/g8hhht/S02E09_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3395:"<item>
+		<title>S02E09: Club in Crisis!!</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e09-club-in-crisis/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e09-club-in-crisis/#comments</comments>
+		<pubDate>Wed, 04 Dec 2013 03:22:19 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/12/04/s02e09-club-in-crisis/</guid>
+		<description><![CDATA[<p>It’s episode 9 this week, and that means we’re one third of the way through the season. The Wanderers played a pretty boring nil-all draw on the weekend, and as a result, just like the team we’re playing next week, we all lose our Kewell. Our resident Spanish Commentator makes his return, but with nothing to commentate on we turn our attention to squad rotation and whether or not it’s a good thing. Speaking of going around in circles, the rest of the podcast includes W-League, Youth League, an “International wrap up”, and more. This is Around the Bloc. <br style="color:rgb(51,51,51);font-family:'lucida grande', tahoma, verdana, arial, sans-serif;line-height:17px;background-color:rgb(255,255,255);" /></p>
+]]></description>
+			<content:encoded><![CDATA[<p>It’s episode 9 this week, and that means we’re one third of the way through the season. The Wanderers played a pretty boring nil-all draw on the weekend, and as a result, just like the team we’re playing next week, we all lose our Kewell. Our resident Spanish Commentator makes his return, but with nothing to commentate on we turn our attention to squad rotation and whether or not it’s a good thing. Speaking of going around in circles, the rest of the podcast includes W-League, Youth League, an “International wrap up”, and more. This is Around the Bloc. <br style="color:rgb(51,51,51);font-family:'lucida grande', tahoma, verdana, arial, sans-serif;line-height:17px;background-color:rgb(255,255,255);" /></p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e09-club-in-crisis/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/g8hhht/S02E09_Around_the_Bloc_podcast.mp3" length="49874549" type="audio/mpeg"/>
+				<itunes:subtitle>It's episode 9 this week, and that means we're one third of the way through the season. The Wanderers played a pretty boring nil-all draw ...</itunes:subtitle>
+		<itunes:summary>It's episode 9 this week, and that means we're one third of the way through the season. The Wanderers played a pretty boring nil-all draw on the weekend, and as a result, just like the team we're playing next week, we all lose our Kewell. Our resident Spanish Commentator makes his return, but with nothing to commentate on we turn our attention to squad rotation and whether or not it's a good thing. Speaking of going around in circles, the rest of the podcast includes W-League, Youth League, an "International wrap up", and more. This is Around the Bloc. </itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:43:54</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E09: Club in Crisis!!</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:34;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"89cded3f6ce98c6dafceb1fb3c5f6403cc1dc88ca57096137677a4faf00e9d4a";s:5:"title";s:38:"S02E08: Scrappy Curtains with Pancakes";s:3:"url";s:73:"http://aroundthebloc.podbean.com/e/s02e08-scrappy-curtains-with-pancakes/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-27 01:05:32.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:624:"<p>Around the Bloc returns for another week and, like Brisbane Roar, is only good for about 20 minutes, but still does enough to see out a full hour and a half. Turner, our resident caped crusader, tells us what he remembers of his antics from the away trip whilst Brendan makes one too many trips to Marconi. The boys finally get to dissect a loss but, with the help of <a href="https://www.facebook.com/hashtag/atbfeedback" rel="noreferrer" target="_blank">#ATBFeedback</a>, are able to see the positives. There’s good news for the Youth League, segues galore, and much much more on this edition of Around the Bloc.
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/jjv4rf/S02E08_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3198:"<item>
+		<title>S02E08: Scrappy Curtains with Pancakes</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e08-scrappy-curtains-with-pancakes/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e08-scrappy-curtains-with-pancakes/#comments</comments>
+		<pubDate>Wed, 27 Nov 2013 01:05:32 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/11/27/s02e08-scrappy-curtains-with-pancakes/</guid>
+		<description><![CDATA[<p>Around the Bloc returns for another week and, like Brisbane Roar, is only good for about 20 minutes, but still does enough to see out a full hour and a half. Turner, our resident caped crusader, tells us what he remembers of his antics from the away trip whilst Brendan makes one too many trips to Marconi. The boys finally get to dissect a loss but, with the help of <a class="_58cn" href="https://www.facebook.com/hashtag/atbfeedback">#ATBFeedback</a>, are able to see the positives. There’s good news for the Youth League, segues galore, and much much more on this edition of Around the Bloc.
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>Around the Bloc returns for another week and, like Brisbane Roar, is only good for about 20 minutes, but still does enough to see out a full hour and a half. Turner, our resident caped crusader, tells us what he remembers of his antics from the away trip whilst Brendan makes one too many trips to Marconi. The boys finally get to dissect a loss but, with the help of <a class="_58cn" href="https://www.facebook.com/hashtag/atbfeedback">#ATBFeedback</a>, are able to see the positives. There’s good news for the Youth League, segues galore, and much much more on this edition of Around the Bloc.
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e08-scrappy-curtains-with-pancakes/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/jjv4rf/S02E08_Around_the_Bloc_podcast.mp3" length="48431336" type="audio/mpeg"/>
+				<itunes:subtitle>Around the Bloc returns for another week and, like Brisbane Roar, is only good for about 20 minutes, but still does enough to see out ...</itunes:subtitle>
+		<itunes:summary>Around the Bloc returns for another week and, like Brisbane Roar, is only good for about 20 minutes, but still does enough to see out a full hour and a half. Turner, our resident caped crusader, tells us what he remembers of his antics from the away trip whilst Brendan makes one too many trips to Marconi. The boys finally get to dissect a loss but, with the help of#ATBFeedback, are able to see the positives. There's good news for the Youth League, segues galore, and much much more on this edition of Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:40:53</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E08: Scrappy Curtains with Pancakes</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:35;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"95d652c913366832bd26c6bc9f9d16da762a8a481939afa7c637338b263f1757";s:5:"title";s:27:"S02E07: Reigning at the Top";s:3:"url";s:62:"http://aroundthebloc.podbean.com/e/s02e07-reigning-at-the-top/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-20 00:45:16.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:703:"<p>It was wet, wet, wet in Parramatta on Saturday night, but the love was certainly not all around in the stadium, with the two arguably biggest and most passionate groups of fans in the A-League battling it out in the stands. It was 82 minutes before Mark Bridge put away the winner, and less than 24 hours later the Wanderers finished the round at the top of the table for the first time this season. The bliss turns to diss in ATBFeedback, the joy for the Wanderers unfortunately stopped short of the W-League and Youth League games, and the Newcastle Jets and Michael Turner both pull off upsets over their opponents in the same game. All this and much more on this edition of Around The Bloc. 
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/nnfgj8/S02E07_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3617:"<item>
+		<title>S02E07: Reigning at the Top</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e07-reigning-at-the-top/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e07-reigning-at-the-top/#comments</comments>
+		<pubDate>Wed, 20 Nov 2013 00:45:16 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/11/20/s02e07-reigning-at-the-top/</guid>
+		<description><![CDATA[<p><span><span style="vertical-align:baseline;">It was wet, wet, wet in Parramatta on Saturday night, but the love was certainly not all around in the stadium, with the two arguably biggest and most passionate groups of fans in the A-League battling it out in the stands. It was 82 minutes before Mark Bridge put away the winner, and less than 24 hours later the Wanderers finished the round at the top of the table for the first time this season. The bliss turns to diss in ATBFeedback, the joy for the Wanderers unfortunately stopped short of the W-League and Youth League games, and the Newcastle Jets and Michael Turner both pull off upsets over their opponents in the same game. All this and much more on this edition of Around The Bloc. </span></span>
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p><span><span style="vertical-align:baseline;">It was wet, wet, wet in Parramatta on Saturday night, but the love was certainly not all around in the stadium, with the two arguably biggest and most passionate groups of fans in the A-League battling it out in the stands. It was 82 minutes before Mark Bridge put away the winner, and less than 24 hours later the Wanderers finished the round at the top of the table for the first time this season. The bliss turns to diss in ATBFeedback, the joy for the Wanderers unfortunately stopped short of the W-League and Youth League games, and the Newcastle Jets and Michael Turner both pull off upsets over their opponents in the same game. All this and much more on this edition of Around The Bloc. </span></span>
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e07-reigning-at-the-top/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/nnfgj8/S02E07_Around_the_Bloc_podcast.mp3" length="38095414" type="audio/mpeg"/>
+				<itunes:subtitle>It was wet, wet, wet in Parramatta on Saturday night, but the love was certainly not all around in the stadium, with the two arguably ...</itunes:subtitle>
+		<itunes:summary>It was wet, wet, wet in Parramatta on Saturday night, but the love was certainly not all around in the stadium, with the two arguably biggest and most passionate groups of fans in the A-League battling it out in the stands. It was 82 minutes before Mark Bridge put away the winner, and less than 24 hours later the Wanderers finished the round at the top of the table for the first time this season. The bliss turns to diss in ATBFeedback, the joy for the Wanderers unfortunately stopped short of the W-League and Youth League games, and the Newcastle Jets and Michael Turner both pull off upsets over their opponents in the same game. All this and much more on this edition of Around The Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:19:21</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E07: Reigning at the Top</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:36;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"bfe8d7e67b45fed021accd333968663f9c04862fea60f7877377b7bde770b290";s:5:"title";s:17:"S02E06: Heartbeat";s:3:"url";s:52:"http://aroundthebloc.podbean.com/e/s02e06-heartbeat/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-13 00:15:01.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:714:"On the day Santalab showed his loyalty to the Wanderers like a Golden Lab to a blind man, the ATB boys are back with another episode more chockers than Parramatta Stadium will be on Saturday night. After a gritty 1-0 win where Cole scored in the cold, TomiGun should’ve kept the safety on and the team had the Heart beat, we look forward to victory over the Victory both on and off the pitch. Cop Watch returns in comical fashion, we report on the start of the W-League and the women and youth teams double header, which was the second one of the weekend after Seb Ryall’s goal from the Big Blue. All this and much more on this edition of Around The Bloc. 
+<br/>Oh…and we interview Foxsport’s Adam Peacock.";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/w4vw3/S02E06_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3798:"<item>
+		<title>S02E06: Heartbeat</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e06-heartbeat/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e06-heartbeat/#comments</comments>
+		<pubDate>Wed, 13 Nov 2013 00:15:01 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/11/13/s02e06-heartbeat/</guid>
+		<description><![CDATA[<div><font face="Arial, Verdana" size="2">On the day Santalab showed his loyalty to the Wanderers like a Golden Lab to a blind man, the ATB boys are back with another episode more chockers than Parramatta Stadium will be on Saturday night. After a gritty 1-0 win where Cole scored in the cold, TomiGun should’ve kept the safety on and the team had the Heart beat, we look forward to victory over the Victory both on and off the pitch. Cop Watch returns in comical fashion, we report on the start of the W-League and the women and youth teams double header, which was the second one of the weekend after Seb Ryall’s goal from the Big Blue. All this and much more on this edition of Around The Bloc. </font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">Oh…and we interview Foxsport’s Adam Peacock.</font></div>
+]]></description>
+			<content:encoded><![CDATA[<div><font face="Arial, Verdana" size="2">On the day Santalab showed his loyalty to the Wanderers like a Golden Lab to a blind man, the ATB boys are back with another episode more chockers than Parramatta Stadium will be on Saturday night. After a gritty 1-0 win where Cole scored in the cold, TomiGun should’ve kept the safety on and the team had the Heart beat, we look forward to victory over the Victory both on and off the pitch. Cop Watch returns in comical fashion, we report on the start of the W-League and the women and youth teams double header, which was the second one of the weekend after Seb Ryall’s goal from the Big Blue. All this and much more on this edition of Around The Bloc. </font></div>
+<div><font face="Arial, Verdana" size="2"><br /></font></div>
+<div><font face="Arial, Verdana" size="2">Oh…and we interview Foxsport’s Adam Peacock.</font></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e06-heartbeat/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/w4vw3/S02E06_Around_the_Bloc_podcast.mp3" length="50199512" type="audio/mpeg"/>
+				<itunes:subtitle>On the day Santalab showed his loyalty to the Wanderers like a Golden Lab to a blind man, the ATB boys are back with another ...</itunes:subtitle>
+		<itunes:summary>On the day Santalab showed his loyalty to the Wanderers like a Golden Lab to a blind man, the ATB boys are back with another episode more chockers than Parramatta Stadium will be on Saturday night. After a gritty 1-0 win where Cole scored in the cold, TomiGun should’ve kept the safety on and the team had the Heart beat, we look forward to victory over the Victory both on and off the pitch. Cop Watch returns in comical fashion, we report on the start of the W-League and the women and youth teams double header, which was the second one of the weekend after Seb Ryall’s goal from the Big Blue. All this and much more on this edition of Around The Bloc.Oh...and we interview Foxsport's Adam Peacock.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:44:34</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E06: Heartbeat</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:37;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"5009b50603a446b32272bec2dd4b0d9526797253818d3a47b4252ed7a9975780";s:5:"title";s:38:"S02E05: Receipt, Deceit, but no Defeat";s:3:"url";s:71:"http://aroundthebloc.podbean.com/e/s02e05-receipt-deceit-but-no-defeat/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-11-06 03:43:33.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:639:"<p>With Speccy benched, ATB is down to 4 men this week. TomiGun© put 2 away at home against the Reds whilst Polenz was lucky that only Adelaide’s secondary kit colour featured amongst the cards shown to him on Friday night. Cop Watch is back, unfortunately, due to fear of a receipt roll planet, and ATBTalkback reveals the pep talks that Wanderers fans would use to pump up the team. Finally, the W-League returns with a double header featuring the WanderWomen and the WanderKids of the National Youth League at Marconi, and the ATB tipping comp receives a shake up. All this and more, on this week’s edition of Around the Bloc.
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/cxfuam/S02E05_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3356:"<item>
+		<title>S02E05: Receipt, Deceit, but no Defeat</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e05-receipt-deceit-but-no-defeat/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e05-receipt-deceit-but-no-defeat/#comments</comments>
+		<pubDate>Wed, 06 Nov 2013 03:43:33 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/11/06/s02e05-receipt-deceit-but-no-defeat/</guid>
+		<description><![CDATA[<p>With Speccy benched, ATB is down to 4 men this week. TomiGun© put 2 away at home against the Reds whilst Polenz was lucky that only Adelaide’s secondary kit colour featured amongst the cards shown to him on Friday night. Cop Watch is back, unfortunately, due to fear of a receipt roll planet, and ATBTalkback reveals the pep talks that Wanderers fans would use to pump up the team. Finally, the W-League returns with a double header featuring the WanderWomen and the WanderKids of the National Youth League at Marconi, and the ATB tipping comp receives a shake up. All this and more, on this week’s edition of Around the Bloc.
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>With Speccy benched, ATB is down to 4 men this week. TomiGun© put 2 away at home against the Reds whilst Polenz was lucky that only Adelaide’s secondary kit colour featured amongst the cards shown to him on Friday night. Cop Watch is back, unfortunately, due to fear of a receipt roll planet, and ATBTalkback reveals the pep talks that Wanderers fans would use to pump up the team. Finally, the W-League returns with a double header featuring the WanderWomen and the WanderKids of the National Youth League at Marconi, and the ATB tipping comp receives a shake up. All this and more, on this week’s edition of Around the Bloc.
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e05-receipt-deceit-but-no-defeat/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/cxfuam/S02E05_Around_the_Bloc_podcast.mp3" length="34842020" type="audio/mpeg"/>
+				<itunes:subtitle>With Speccy benched, ATB is down to 4 men this week. TomiGun© put 2 away at home against the Reds whilst Polenz was lucky that ...</itunes:subtitle>
+		<itunes:summary>With Speccy benched, ATB is down to 4 men this week. TomiGun© put 2 away at home against the Reds whilst Polenz was lucky that only Adelaide's secondary kit colour featured amongst the cards shown to him on Friday night. Cop Watch is back, unfortunately, due to fear of a receipt roll planet, and ATBTalkback reveals the pep talks that Wanderers fans would use to pump up the team. Finally, the W-League returns with a double header featuring the WanderWomen and the WanderKids of the National Youth League at Marconi, and the ATB tipping comp receives a shake up. All this and more, on this week's edition of Around the Bloc.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:36:46</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E05: Receipt, Deceit, but no Defeat</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:38;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"7b2fad97ff41c9b417d947c5148fcc0bb244f4421500dc97fcb9429a2476d6ab";s:5:"title";s:41:"S02E04: A better love story than Twilight";s:3:"url";s:76:"http://aroundthebloc.podbean.com/e/s02e04-a-better-love-story-than-twilight/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-30 01:04:54.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:683:"<p>Around the Bloc has a special announcement - this week, we talk about football! The beautiful game is back in the spotlight as the Wanderers defeat Sydney FC in the first Derby D’Sydney of the season. Speccy turned up, Brendan was there too but… also kind of wasn’t, Ivan revelled in the cool, fresh air (for most of the night), Turner made the papers again and Stephen got to make fun of everyone for all of the above. Aside from a few exceptions, the Police and media were generally well-behaved.<br/>We find out what rituals different Wanderers fans have pre-game in ATBTalkback and preview our first game to be aired live, on free-to-air TV against Adelaide United.
+</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/wjeiq5/S02E04_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3536:"<item>
+		<title>S02E04: A better love story than Twilight</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e04-a-better-love-story-than-twilight/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e04-a-better-love-story-than-twilight/#comments</comments>
+		<pubDate>Wed, 30 Oct 2013 01:04:54 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/10/30/s02e04-a-better-love-story-than-twilight/</guid>
+		<description><![CDATA[<p>Around the Bloc has a special announcement - this week, we talk about football! The beautiful game is back in the spotlight as the Wanderers defeat Sydney FC in the first Derby D’Sydney of the season. Speccy turned up, Brendan was there too but… also kind of wasn’t, Ivan revelled in the cool, fresh air (for most of the night), Turner made the papers again and Stephen got to make fun of everyone for all of the above. Aside from a few exceptions, the Police and media were generally well-behaved.<br /><br />We find out what rituals different Wanderers fans have pre-game in ATBTalkback and preview our first game to be aired live, on free-to-air TV against Adelaide United.
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>Around the Bloc has a special announcement - this week, we talk about football! The beautiful game is back in the spotlight as the Wanderers defeat Sydney FC in the first Derby D’Sydney of the season. Speccy turned up, Brendan was there too but… also kind of wasn’t, Ivan revelled in the cool, fresh air (for most of the night), Turner made the papers again and Stephen got to make fun of everyone for all of the above. Aside from a few exceptions, the Police and media were generally well-behaved.<br /><br />We find out what rituals different Wanderers fans have pre-game in ATBTalkback and preview our first game to be aired live, on free-to-air TV against Adelaide United.
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e04-a-better-love-story-than-twilight/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/wjeiq5/S02E04_Around_the_Bloc_podcast.mp3" length="28720433" type="audio/mpeg"/>
+				<itunes:subtitle>Around the Bloc has a special announcement - this week, we talk about football! The beautiful game is back in the spotlight as the Wanderers ...</itunes:subtitle>
+		<itunes:summary>Around the Bloc has a special announcement - this week, we talk about football! The beautiful game is back in the spotlight as the Wanderers defeat Sydney FC in the first Derby D'Sydney of the season. Speccy turned up, Brendan was there too but... also kind of wasn't, Ivan revelled in the cool, fresh air (for most of the night), Turner made the papers again and Stephen got to make fun of everyone for all of the above. Aside from a few exceptions, the Police and media were generally well-behaved.We find out what rituals different Wanderers fans have pre-game in ATBTalkback and preview our first game to be aired live, on free-to-air TV against Adelaide United.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:19:46</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E04: A better love story than Twilight</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:39;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"dc933486dcb16368f6cb66f2f4d0dcb8a437ba6ad216b40454edcf7cf2c9ab92";s:5:"title";s:32:"S02E03: To the left, to the left";s:3:"url";s:66:"http://aroundthebloc.podbean.com/e/s02e03-to-the-left-to-the-left/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-23 00:36:44.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:686:"<p>Football is, for once, the minor topic on this week’s podcast, as we are unfortunately forced to turn our attention to towards the over handed approach the authorities are taking towards Western Sydney’s football fans. Ivan interviews Chadi (a Defence Attorney), Danielle (whose relatives were victims of these tactics), and none other than Lyall Gorman, Wanderers CEO, to get their opinions on what is fast becoming the biggest issue we are facing when supporting our sport.</p>
+<p>On a lighter note, we DO actually talk about football, with the 1-1 against Wellington last week, and the Derby D’Sydney coming up, and Nick Nova’s ‘Do You Even Dale?’ makes its debut.</p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/vqtbpc/S02E03_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3595:"<item>
+		<title>S02E03: To the left, to the left</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e03-to-the-left-to-the-left/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e03-to-the-left-to-the-left/#comments</comments>
+		<pubDate>Wed, 23 Oct 2013 00:36:44 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/10/23/s02e03-to-the-left-to-the-left/</guid>
+		<description><![CDATA[<p style="margin:0px 0px 24px;">Football is, for once, the minor topic on this week’s podcast, as we are unfortunately forced to turn our attention to towards the over handed approach the authorities are taking towards Western Sydney’s football fans. Ivan interviews Chadi (a Defence Attorney), Danielle (whose relatives were victims of these tactics), and none other than Lyall Gorman, Wanderers CEO, to get their opinions on what is fast becoming the biggest issue we are facing when supporting our sport.</p>
+<p style="margin:0px 0px 24px;">On a lighter note, we DO actually talk about football, with the 1-1 against Wellington last week, and the Derby D’Sydney coming up, and Nick Nova’s ‘Do You Even Dale?’ makes its debut.</p>
+]]></description>
+			<content:encoded><![CDATA[<p style="margin:0px 0px 24px;">Football is, for once, the minor topic on this week’s podcast, as we are unfortunately forced to turn our attention to towards the over handed approach the authorities are taking towards Western Sydney’s football fans. Ivan interviews Chadi (a Defence Attorney), Danielle (whose relatives were victims of these tactics), and none other than Lyall Gorman, Wanderers CEO, to get their opinions on what is fast becoming the biggest issue we are facing when supporting our sport.</p>
+<p style="margin:0px 0px 24px;">On a lighter note, we DO actually talk about football, with the 1-1 against Wellington last week, and the Derby D’Sydney coming up, and Nick Nova’s ‘Do You Even Dale?’ makes its debut.</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e03-to-the-left-to-the-left/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/vqtbpc/S02E03_Around_the_Bloc_podcast.mp3" length="34373384" type="audio/mpeg"/>
+				<itunes:subtitle>Football is, for once, the minor topic on this week’s podcast, as we are unfortunately forced to turn our attention to towards the over handed ...</itunes:subtitle>
+		<itunes:summary>Football is, for once, the minor topic on this week’s podcast, as we are unfortunately forced to turn our attention to towards the over handed approach the authorities are taking towards Western Sydney’s football fans. Ivan interviews Chadi (a Defence Attorney), Danielle (whose relatives were victims of these tactics), and none other than Lyall Gorman, Wanderers CEO, to get their opinions on what is fast becoming the biggest issue we are facing when supporting our sport.On a lighter note, we DO actually talk about football, with the 1-1 against Wellington last week, and the Derby D’Sydney coming up, and Nick Nova’s ‘Do You Even Dale?’ makes its debut.</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:35:28</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E03: To the left, to the left</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:40;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"a6a23d90ea8c5165a8029d9aa86dec6285c68000bbf43c3d5db0483fafd48571";s:5:"title";s:19:"S02E02: Say Cheese!";s:3:"url";s:53:"http://aroundthebloc.podbean.com/e/s02e02-say-cheese/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-16 01:19:39.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:310:"<p>The team get together this week and discuss issues such as the RBB becoming the new stars of ‘Australia’s funniest home surveillance videos’, all the news from the latest Wanderers fan forum, a preview of our first home game of the season and much more, on this edition of Around the Bloc…</p>
+<br/>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/ncxtdb/S02E02_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:2890:"<item>
+		<title>S02E02: Say Cheese!</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e02-say-cheese/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e02-say-cheese/#comments</comments>
+		<pubDate>Wed, 16 Oct 2013 01:19:39 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/10/16/s02e02-say-cheese/</guid>
+		<description><![CDATA[<p><span></span>
+</p><p dir="ltr" style="line-height:1.15;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;">The team get together this week and discuss issues such as the RBB becoming the new stars of ‘Australia’s funniest home surveillance videos’, all the news from the latest Wanderers fan forum, a preview of our first home game of the season and much more, on this edition of Around the Bloc…</span></p>
+<div><span style="font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;"><br /></span></div>
+]]></description>
+			<content:encoded><![CDATA[<p><span></span>
+</p><p dir="ltr" style="line-height:1.15;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;">The team get together this week and discuss issues such as the RBB becoming the new stars of ‘Australia’s funniest home surveillance videos’, all the news from the latest Wanderers fan forum, a preview of our first home game of the season and much more, on this edition of Around the Bloc…</span></p>
+<div><span style="font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;"><br /></span></div>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e02-say-cheese/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/ncxtdb/S02E02_Around_the_Bloc_podcast.mp3" length="31226621" type="audio/mpeg"/>
+				<itunes:subtitle>The team get together this week and discuss issues such as the RBB becoming the new stars of ‘Australia’s funniest home surveillance videos’, all the ...</itunes:subtitle>
+		<itunes:summary>The team get together this week and discuss issues such as the RBB becoming the new stars of ‘Australia’s funniest home surveillance videos’, all the news from the latest Wanderers fan forum, a preview of our first home game of the season and much more, on this edition of Around the Bloc...</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:26:44</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E02: Say Cheese!</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:41;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"3a1608c23c152ba35d07ea731117aa0595037b863dce10e73c0b8f63204f889a";s:5:"title";s:35:"S02E01: The Difficult Second Season";s:3:"url";s:70:"http://aroundthebloc.podbean.com/e/s02e01-the-difficult-second-season/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-10-09 05:23:27.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:379:"<p>The Around the Bloc team take our seats once more for another exciting year of banter as we attempt to defend our Podcast D’Or award.</p>
+<p>On this weeks episode we talk A-League, W-League, Youth League and Powerchair League, get an update on those schnitzel rolls from Campbelltown Stadium, discuss the ins, outs, ups and downs of the off season and much much more… </p>";s:13:"enclosure_url";s:82:"http://aroundthebloc.podbean.com/mf/feed/hjuu3c/S02E01_Around_the_Bloc_podcast.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3742:"<item>
+		<title>S02E01: The Difficult Second Season</title>
+		<link>http://aroundthebloc.podbean.com/e/s02e01-the-difficult-second-season/</link>
+		<comments>http://aroundthebloc.podbean.com/e/s02e01-the-difficult-second-season/#comments</comments>
+		<pubDate>Wed, 09 Oct 2013 05:23:27 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/10/09/s02e01-the-difficult-second-season/</guid>
+		<description><![CDATA[<p><span></span>
+</p><p dir="ltr" style="line-height:1.15;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;">The Around the Bloc team take our seats once more for another exciting year of banter as we attempt to defend our Podcast D’Or award.</span></p>
+<p dir="ltr" style="line-height:1.15;margin-top:0pt;margin-bottom:0pt;"><span style="line-height:normal;font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;">On this weeks episode we talk A-League, W-League, Youth League and Powerchair League, get an update on </span><span style="line-height:normal;font-size:15px;font-family:Arial;font-style:italic;vertical-align:baseline;white-space:pre-wrap;">those</span><span style="line-height:normal;font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;"> schnitzel rolls from  [...]</span></p>]]></description>
+			<content:encoded><![CDATA[<p><span></span>
+</p><p dir="ltr" style="line-height:1.15;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;">The Around the Bloc team take our seats once more for another exciting year of banter as we attempt to defend our Podcast D’Or award.</span></p>
+<p dir="ltr" style="line-height:1.15;margin-top:0pt;margin-bottom:0pt;"><span style="line-height:normal;font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;">On this weeks episode we talk A-League, W-League, Youth League and Powerchair League, get an update on </span><span style="line-height:normal;font-size:15px;font-family:Arial;font-style:italic;vertical-align:baseline;white-space:pre-wrap;">those</span><span style="line-height:normal;font-size:15px;font-family:Arial;vertical-align:baseline;white-space:pre-wrap;"> schnitzel rolls from Campbelltown Stadium, discuss the ins, outs, ups and downs of the off season and much much more… </span></p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/s02e01-the-difficult-second-season/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/hjuu3c/S02E01_Around_the_Bloc_podcast.mp3" length="44325096" type="audio/mpeg"/>
+				<itunes:subtitle>The Around the Bloc team take our seats once more for another exciting year of banter as we attempt to defend our Podcast D'Or award.On ...</itunes:subtitle>
+		<itunes:summary>The Around the Bloc team take our seats once more for another exciting year of banter as we attempt to defend our Podcast D'Or award.On this weeks episode we talk A-League, W-League, Youth League and Powerchair League, get an update on those schnitzel rolls from Campbelltown Stadium, discuss the ins, outs, ups and downs of the off season and much much more...</itunes:summary>
+		<itunes:keywords/>		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>02:03:07</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/bqvk38/ATBLogo.jpg" medium="image">
+					<media:title type="html">S02E01: The Difficult Second Season</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:42;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"400c94b0f101c91f83d45b38af45b6289d36a02a5f8ea36c29ccf82a42a00b9a";s:5:"title";s:31:"Episode 24: Grand Final relapse";s:3:"url";s:66:"http://aroundthebloc.podbean.com/e/episode-24-grand-final-relapse/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-25 08:54:57.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:616:"<p>In the season finale JAR, Speccy, Turner &amp; Erebus grieve together over the grand final loss but fondly look back at the Wanderers’ very successful first season. We discuss season highlights in #ATBTalkback and recap the parade in Parramatta and the WSW awards night. Thanks to all our listeners and contributors over the season and we’ll be back next season bigger and better! Check us out on twitter - <a href="http://twitter.com/ATBWSW" rel="noreferrer" target="_blank">@ATBWSW</a> - or <a href="http://www.facebook.com/AroundTheBloc" rel="noreferrer" target="_blank">facebook.com/AroundTheBloc</a>
+</p>";s:13:"enclosure_url";s:80:"http://aroundthebloc.podbean.com/mf/feed/z5umt/Around_the_Bloc_podcast_ep024.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3008:"<item>
+		<title>Episode 24: Grand Final relapse</title>
+		<link>http://aroundthebloc.podbean.com/e/episode-24-grand-final-relapse/</link>
+		<comments>http://aroundthebloc.podbean.com/e/episode-24-grand-final-relapse/#comments</comments>
+		<pubDate>Thu, 25 Apr 2013 08:54:57 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/04/25/episode-24-grand-final-relapse/</guid>
+		<description><![CDATA[<p>In the season finale JAR, Speccy, Turner &#38; Erebus grieve together over the grand final loss but fondly look back at the Wanderers’ very successful first season. We discuss season highlights in #ATBTalkback and recap the parade in Parramatta and the WSW awards night. Thanks to all our listeners and contributors over the season and we’ll be back next season bigger and better! Check us out on twitter - <a href="http://twitter.com/ATBWSW">@ATBWSW</a> - or <a href="http://www.facebook.com/AroundTheBloc">facebook.com/AroundTheBloc</a>
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>In the season finale JAR, Speccy, Turner &amp; Erebus grieve together over the grand final loss but fondly look back at the Wanderers’ very successful first season. We discuss season highlights in #ATBTalkback and recap the parade in Parramatta and the WSW awards night. Thanks to all our listeners and contributors over the season and we’ll be back next season bigger and better! Check us out on twitter - <a href="http://twitter.com/ATBWSW">@ATBWSW</a> - or <a href="http://www.facebook.com/AroundTheBloc">facebook.com/AroundTheBloc</a>
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/episode-24-grand-final-relapse/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/z5umt/Around_the_Bloc_podcast_ep024.mp3" length="22339608" type="audio/mpeg"/>
+				<itunes:subtitle>In the season finale JAR, Speccy, Turner  Erebus grieve together over the grand final loss but fondly look back at the Wanderers' very successful ...</itunes:subtitle>
+		<itunes:summary>In the season finale JAR, Speccy, Turner  Erebus grieve together over the grand final loss but fondly look back at the Wanderers' very successful first season. We discuss season highlights in #ATBTalkback and recap the parade in Parramatta and the WSW awards night. Thanks to all our listeners and contributors over the season and we'll be back next season bigger and better! Check us out on twitter - @ATBWSW - or facebook.com/AroundTheBloc</itunes:summary>
+		<itunes:keywords>a-league, western sydney wanderers, football, australia, soccer</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+			<media:content url="http://aroundthebloc.podbean.com/mf/web/dvxajq/LOGO.jpg" medium="image">
+					<media:title type="html">Episode 24: Grand Final relapse</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:43;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"039cdc6ba289e62ff83bbe7becd07a37dc0913d05335b76938040968217e8bd7";s:5:"title";s:32:"Episode 23: Stadium Wide Pozcast";s:3:"url";s:67:"http://aroundthebloc.podbean.com/e/episode-23-stadium-wide-pozcast/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-18 02:27:18.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:331:"<p>JAR, Speccy, Turner &amp; Erebus talk about two of the most important games in our clubs history - the Semi Final against Brisbane Roar, and the impending Grand Final against Central Coast Mariners. #ATBTalkback returns and actually kind of works this time. Check us out on twitter - @ATBWSW - or facebook.com/AroundTheBloc
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/5u3u83/Around_the_bloc_podcast_ep023.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:2461:"<item>
+		<title>Episode 23: Stadium Wide Pozcast</title>
+		<link>http://aroundthebloc.podbean.com/e/episode-23-stadium-wide-pozcast/</link>
+		<comments>http://aroundthebloc.podbean.com/e/episode-23-stadium-wide-pozcast/#comments</comments>
+		<pubDate>Thu, 18 Apr 2013 02:27:18 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/04/17/episode-23-stadium-wide-pozcast/</guid>
+		<description><![CDATA[<p>JAR, Speccy, Turner &#38; Erebus talk about two of the most important games in our clubs history - the Semi Final against Brisbane Roar, and the impending Grand Final against Central Coast Mariners. #ATBTalkback returns and actually kind of works this time. Check us out on twitter - @ATBWSW - or facebook.com/AroundTheBloc
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>JAR, Speccy, Turner &amp; Erebus talk about two of the most important games in our clubs history - the Semi Final against Brisbane Roar, and the impending Grand Final against Central Coast Mariners. #ATBTalkback returns and actually kind of works this time. Check us out on twitter - @ATBWSW - or facebook.com/AroundTheBloc
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/episode-23-stadium-wide-pozcast/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/5u3u83/Around_the_bloc_podcast_ep023.mp3" length="20898171" type="audio/mpeg"/>
+				<itunes:subtitle>JAR, Speccy, Turner  Erebus talk about two of the most important games in our clubs history - the Semi Final against Brisbane Roar, and ...</itunes:subtitle>
+		<itunes:summary>JAR, Speccy, Turner  Erebus talk about two of the most important games in our clubs history - the Semi Final against Brisbane Roar, and the impending Grand Final against Central Coast Mariners. #ATBTalkback returns and actually kind of works this time. Check us out on twitter - @ATBWSW - or facebook.com/AroundTheBloc</itunes:summary>
+		<itunes:keywords>around the bloc, western sydney wanders, rbb, football, soccer, aleague, wsw rbb</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+			<media:content url="http://aroundthebloc.podbean.com/mf/web/dvxajq/LOGO.jpg" medium="image">
+					<media:title type="html">Episode 23: Stadium Wide Pozcast</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:44;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"58b057fab6eb2f643ef9d5962d1c42961a97001ffa27c5f18446d3cde920aaa4";s:5:"title";s:53:"Episode 22: Wait a minute? You Guys didn’t play?!?!";s:3:"url";s:80:"http://aroundthebloc.podbean.com/e/episode-22-wait-a-minute-you-guys-didnt-play/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-11 01:18:29.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:637:"<p>FFDU Nominated Finalist; Around the Bloc are joined by Erebus, JAR, Turner &amp; Speccy as they smash through a quick episode (for our standards) discussing the sudden death finals that have happened over the weekend, the upcoming semi final against Brisbane which has got everyone talking! Listen in for details regarding the march, our predictions, Speccy finally winning ‘guess a player’ segment to bring Erebus’ winning streak to an end and our resident Latin correspondent; Pistola giving us an indepth interview! Follow us on twitter ‘@ATBWSW’, like us on Facebook; ‘Around the Bloc’ and subscribe via iTunes!
+</p>";s:13:"enclosure_url";s:80:"http://aroundthebloc.podbean.com/mf/feed/n3dme/Around_the_bloc_podcast_ep022.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3468:"<item>
+		<title>Episode 22: Wait a minute? You Guys didn’t play?!?!</title>
+		<link>http://aroundthebloc.podbean.com/e/episode-22-wait-a-minute-you-guys-didnt-play/</link>
+		<comments>http://aroundthebloc.podbean.com/e/episode-22-wait-a-minute-you-guys-didnt-play/#comments</comments>
+		<pubDate>Thu, 11 Apr 2013 01:18:29 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/04/10/episode-22-wait-a-minute-you-guys-didnt-play/</guid>
+		<description><![CDATA[<p>FFDU Nominated Finalist; Around the Bloc are joined by Erebus, JAR, Turner &#38; Speccy as they smash through a quick episode (for our standards) discussing the sudden death finals that have happened over the weekend, the upcoming semi final against Brisbane which has got everyone talking! Listen in for details regarding the march, our predictions, Speccy finally winning ‘guess a player’ segment to bring Erebus’ winning streak to an end and our resident Latin correspondent; Pistola giving us an indepth interview! Follow us on twitter ‘@ATBWSW’, like us on Facebook; ‘Around the Bloc’ and subscribe via iTunes!
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>FFDU Nominated Finalist; Around the Bloc are joined by Erebus, JAR, Turner &amp; Speccy as they smash through a quick episode (for our standards) discussing the sudden death finals that have happened over the weekend, the upcoming semi final against Brisbane which has got everyone talking! Listen in for details regarding the march, our predictions, Speccy finally winning ‘guess a player’ segment to bring Erebus’ winning streak to an end and our resident Latin correspondent; Pistola giving us an indepth interview! Follow us on twitter ‘@ATBWSW’, like us on Facebook; ‘Around the Bloc’ and subscribe via iTunes!
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/episode-22-wait-a-minute-you-guys-didnt-play/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/n3dme/Around_the_bloc_podcast_ep022.mp3" length="15142455" type="audio/mpeg"/>
+				<itunes:subtitle>FFDU Nominated Finalist; Around the Bloc are joined by Erebus, JAR, Turner  Speccy as they smash through a quick episode (for our standards) discussing ...</itunes:subtitle>
+		<itunes:summary>FFDU Nominated Finalist; Around the Bloc are joined by Erebus, JAR, Turner  Speccy as they smash through a quick episode (for our standards) discussing the sudden death finals that have happened over the weekend, the upcoming semi final against Brisbane which has got everyone talking! Listen in for details regarding the march, our predictions, Speccy finally winning 'guess a player' segment to bring Erebus' winning streak to an end and our resident Latin correspondent; Pistola giving us an indepth interview! Follow us on twitter '@ATBWSW', like us on Facebook; 'Around the Bloc' and subscribe via iTunes!</itunes:summary>
+		<itunes:keywords>aleague   ffa   westernsydneywanderers   rbb   football   australia</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+			<media:content url="http://aroundthebloc.podbean.com/mf/web/vda4xf/twitterlogo.png" medium="image">
+					<media:title type="html">Episode 22: Wait a minute? You Guys didn’t play?!?!</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:45;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"371ae51388bc263cf23a0f85d646e62f9b46c08762272a35af26d8781a9e358f";s:5:"title";s:46:"Episode 21: Campeone, Campeone, Ole, Ole, Ole!";s:3:"url";s:76:"http://aroundthebloc.podbean.com/e/episode-21-campeone-campeone-ole-ole-ole/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-04-04 03:27:32.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:677:"<p>Speccy returns and joins JAR, Erebus and a slightly inebriated Turner to discuss and celebrate the Wanderers winning the premiership in their first year as a football club. The release date of this podcast, April 4th, 2013, also happens to be the Wanderers first birthday (i.e. 1 year since the PM announced that it would be happening). A lot has happened since then, but despite the length of the podcast, not all of it is discussed as we stick to the most important parts of the last week. The team recorded on the day of the Newcastle game and that audio is included too. Also: ATB Talkback, Spanish Commentary from Pistola and more. Check us out on twitter @ATBWSW.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/ypjrdm/Around_the_bloc_podcast_ep021.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3588:"<item>
+		<title>Episode 21: Campeone, Campeone, Ole, Ole, Ole!</title>
+		<link>http://aroundthebloc.podbean.com/e/episode-21-campeone-campeone-ole-ole-ole/</link>
+		<comments>http://aroundthebloc.podbean.com/e/episode-21-campeone-campeone-ole-ole-ole/#comments</comments>
+		<pubDate>Thu, 04 Apr 2013 03:27:32 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/04/03/episode-21-campeone-campeone-ole-ole-ole/</guid>
+		<description><![CDATA[<p>Speccy returns and joins JAR, Erebus and a slightly inebriated Turner to discuss and celebrate the Wanderers winning the premiership in their first year as a football club. The release date of this podcast, April 4th, 2013, also happens to be the Wanderers first birthday (i.e. 1 year since the PM announced that it would be happening). A lot has happened since then, but despite the length of the podcast, not all of it is discussed as we stick to the most important parts of the last week. The team recorded on the day of the Newcastle game and that audio is included too. Also: ATB Talkback, Spanish Commentary from Pistola and more. Check us out on twitter @ATBWSW.
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>Speccy returns and joins JAR, Erebus and a slightly inebriated Turner to discuss and celebrate the Wanderers winning the premiership in their first year as a football club. The release date of this podcast, April 4th, 2013, also happens to be the Wanderers first birthday (i.e. 1 year since the PM announced that it would be happening). A lot has happened since then, but despite the length of the podcast, not all of it is discussed as we stick to the most important parts of the last week. The team recorded on the day of the Newcastle game and that audio is included too. Also: ATB Talkback, Spanish Commentary from Pistola and more. Check us out on twitter @ATBWSW.
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/episode-21-campeone-campeone-ole-ole-ole/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/ypjrdm/Around_the_bloc_podcast_ep021.mp3" length="25034922" type="audio/mpeg"/>
+				<itunes:subtitle>Speccy returns and joins JAR, Erebus and a slightly inebriated Turner to discuss and celebrate the Wanderers winning the premiership in their first year as ...</itunes:subtitle>
+		<itunes:summary>Speccy returns and joins JAR, Erebus and a slightly inebriated Turner to discuss and celebrate the Wanderers winning the premiership in their first year as a football club. The release date of this podcast, April 4th, 2013, also happens to be the Wanderers first birthday (i.e. 1 year since the PM announced that it would be happening). A lot has happened since then, but despite the length of the podcast, not all of it is discussed as we stick to the most important parts of the last week. The team recorded on the day of the Newcastle game and that audio is included too. Also: ATB Talkback, Spanish Commentary from Pistola and more. Check us out on twitter @ATBWSW.</itunes:summary>
+		<itunes:keywords>around the bloc, western sydney wanders, rbb, football, soccer, aleague, wsw rbb</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+			<media:content url="http://aroundthebloc.podbean.com/mf/web/dvxajq/LOGO.jpg" medium="image">
+					<media:title type="html">Episode 21: Campeone, Campeone, Ole, Ole, Ole!</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:46;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"078fb324759d5bbc9ca5db3f2323fa13ee25909ebabaaabc2901fa8d78a4d0ea";s:5:"title";s:21:"Episode 20: Milestone";s:3:"url";s:56:"http://aroundthebloc.podbean.com/e/episode-20-milestone/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-28 01:41:45.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:650:"<p>In the absence of Speccy once again, JAR, Erebus and Turner discuss football, and realise they are the only ‘media’ outlet in Sydney doing so this week. The actual match that was played between the Wanderers and Sydney FC is discussed, as opposed to off-field incident’s which everyone is sick of hearing about, along with everyones chances of making the finals (which admittedly gets a bit confusing), the transport and the RBBQ before the last regular season game in Newcastle, and turners infamous ‘Who Am I?’ segment gets another run. TWCDBLW possibly meets it’s untimely demise too. Check out www.twitter.com/ATBWSW for more.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/x2bb3k/Around_the_bloc_podcast_ep020.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3351:"<item>
+		<title>Episode 20: Milestone</title>
+		<link>http://aroundthebloc.podbean.com/e/episode-20-milestone/</link>
+		<comments>http://aroundthebloc.podbean.com/e/episode-20-milestone/#comments</comments>
+		<pubDate>Thu, 28 Mar 2013 01:41:45 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/03/27/episode-20-milestone/</guid>
+		<description><![CDATA[<p>In the absence of Speccy once again, JAR, Erebus and Turner discuss football, and realise they are the only ‘media’ outlet in Sydney doing so this week. The actual match that was played between the Wanderers and Sydney FC is discussed, as opposed to off-field incident’s which everyone is sick of hearing about, along with everyones chances of making the finals (which admittedly gets a bit confusing), the transport and the RBBQ before the last regular season game in Newcastle, and turners infamous ‘Who Am I?’ segment gets another run. TWCDBLW possibly meets it’s untimely demise too. Check out www.twitter.com/ATBWSW for more.
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>In the absence of Speccy once again, JAR, Erebus and Turner discuss football, and realise they are the only ‘media’ outlet in Sydney doing so this week. The actual match that was played between the Wanderers and Sydney FC is discussed, as opposed to off-field incident’s which everyone is sick of hearing about, along with everyones chances of making the finals (which admittedly gets a bit confusing), the transport and the RBBQ before the last regular season game in Newcastle, and turners infamous ‘Who Am I?’ segment gets another run. TWCDBLW possibly meets it’s untimely demise too. Check out www.twitter.com/ATBWSW for more.
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/episode-20-milestone/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/x2bb3k/Around_the_bloc_podcast_ep020.mp3" length="21393766" type="audio/mpeg"/>
+				<itunes:subtitle>In the absence of Speccy once again, JAR, Erebus and Turner discuss football, and realise they are the only 'media' outlet in Sydney doing so ...</itunes:subtitle>
+		<itunes:summary>In the absence of Speccy once again, JAR, Erebus and Turner discuss football, and realise they are the only 'media' outlet in Sydney doing so this week. The actual match that was played between the Wanderers and Sydney FC is discussed, as opposed to off-field incident's which everyone is sick of hearing about, along with everyones chances of making the finals (which admittedly gets a bit confusing), the transport and the RBBQ before the last regular season game in Newcastle, and turners infamous 'Who Am I?' segment gets another run. TWCDBLW possibly meets it's untimely demise too. Check out www.twitter.com/ATBWSW for more.</itunes:summary>
+		<itunes:keywords>around the bloc, western sydney wanders, rbb, football, soccer, aleague, wsw rbb</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+			<media:content url="http://aroundthebloc.podbean.com/mf/web/dvxajq/LOGO.jpg" medium="image">
+					<media:title type="html">Episode 20: Milestone</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:47;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"84a919d97cd1f33ae8357fd99ace2c8ab2d7fe9101536f2d94ced27b797cb0a7";s:5:"title";s:38:"Episode 19: And Then There Were Two…";s:3:"url";s:70:"http://aroundthebloc.podbean.com/e/episode-19-and-then-there-were-two/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-21 03:52:37.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:458:"<p>JAR and Turner are left to their own devices by an absent Speccy and Erebus and quite frankly, they control the ship just nicely. The dynamic duo cut a boosegump inducing promo for the upcoming derby, discuss the Heart game and the infamous ‘incident’ that occurred. Dicko has his say about that too. Details for the FFDU awards, the Newcastle RBBBBBQB and #ATBTalkback also feature in this episode. Check out www.westsydneyfootball.com for more.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/w8qsxz/Around_the_bloc_podcast_ep019.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:2909:"<item>
+		<title>Episode 19: And Then There Were Two…</title>
+		<link>http://aroundthebloc.podbean.com/e/episode-19-and-then-there-were-two/</link>
+		<comments>http://aroundthebloc.podbean.com/e/episode-19-and-then-there-were-two/#comments</comments>
+		<pubDate>Thu, 21 Mar 2013 03:52:37 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/03/20/episode-19-and-then-there-were-two/</guid>
+		<description><![CDATA[<p>JAR and Turner are left to their own devices by an absent Speccy and Erebus and quite frankly, they control the ship just nicely. The dynamic duo cut a boosegump inducing promo for the upcoming derby, discuss the Heart game and the infamous ‘incident’ that occurred. Dicko has his say about that too. Details for the FFDU awards, the Newcastle RBBBBBQB and #ATBTalkback also feature in this episode. Check out www.westsydneyfootball.com for more.
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>JAR and Turner are left to their own devices by an absent Speccy and Erebus and quite frankly, they control the ship just nicely. The dynamic duo cut a boosegump inducing promo for the upcoming derby, discuss the Heart game and the infamous ‘incident’ that occurred. Dicko has his say about that too. Details for the FFDU awards, the Newcastle RBBBBBQB and #ATBTalkback also feature in this episode. Check out www.westsydneyfootball.com for more.
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/episode-19-and-then-there-were-two/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/w8qsxz/Around_the_bloc_podcast_ep019.mp3" length="25989958" type="audio/mpeg"/>
+				<itunes:subtitle>JAR and Turner are left to their own devices by an absent Speccy and Erebus and quite frankly, they control the ship just nicely. The ...</itunes:subtitle>
+		<itunes:summary>JAR and Turner are left to their own devices by an absent Speccy and Erebus and quite frankly, they control the ship just nicely. The dynamic duo cut a boosegump inducing promo for the upcoming derby, discuss the Heart game and the infamous 'incident' that occurred. Dicko has his say about that too. Details for the FFDU awards, the Newcastle RBBBBBQB and #ATBTalkback also feature in this episode. Check out www.westsydneyfootball.com for more.</itunes:summary>
+		<itunes:keywords>around the bloc, western sydney wanders, rbb, football, soccer, aleague, wsw rbb</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+		<itunes:duration>01:48:17</itunes:duration>
+	<media:content url="http://aroundthebloc.podbean.com/mf/web/dvxajq/LOGO.jpg" medium="image">
+					<media:title type="html">Episode 19: And Then There Were Two…</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:48;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"0c58ecb9d07513d17fdfcdfb596507bc7aaa35186bee19f534cb12b3e94dccd5";s:5:"title";s:52:"Episode 18: Seriously this time… Back to our Roots";s:3:"url";s:84:"http://aroundthebloc.podbean.com/e/episode-18-seriously-this-time-back-to-our-roots/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-14 05:30:11.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:359:"<p>JAR, Speccy, Turner and Erebus grab the constructive criticism received through the week by the horns and go back to what they do best. The infamous silent protest is covered along with the game against Wellington, the upcoming game against Heart, the tickets given to underprivileged kids and much more. Check out www.westsydneyfootball.com for more.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/4thrnf/Around_the_bloc_podcast_ep018.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:2662:"<item>
+		<title>Episode 18: Seriously this time… Back to our Roots</title>
+		<link>http://aroundthebloc.podbean.com/e/episode-18-seriously-this-time-back-to-our-roots/</link>
+		<comments>http://aroundthebloc.podbean.com/e/episode-18-seriously-this-time-back-to-our-roots/#comments</comments>
+		<pubDate>Thu, 14 Mar 2013 05:30:11 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/03/13/episode-18-seriously-this-time-back-to-our-roots/</guid>
+		<description><![CDATA[<p>JAR, Speccy, Turner and Erebus grab the constructive criticism received through the week by the horns and go back to what they do best. The infamous silent protest is covered along with the game against Wellington, the upcoming game against Heart, the tickets given to underprivileged kids and much more. Check out www.westsydneyfootball.com for more.
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>JAR, Speccy, Turner and Erebus grab the constructive criticism received through the week by the horns and go back to what they do best. The infamous silent protest is covered along with the game against Wellington, the upcoming game against Heart, the tickets given to underprivileged kids and much more. Check out www.westsydneyfootball.com for more.
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/episode-18-seriously-this-time-back-to-our-roots/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/4thrnf/Around_the_bloc_podcast_ep018.mp3" length="26424114" type="audio/mpeg"/>
+				<itunes:subtitle>JAR, Speccy, Turner and Erebus grab the constructive criticism received through the week by the horns and go back to what they do best. The ...</itunes:subtitle>
+		<itunes:summary>JAR, Speccy, Turner and Erebus grab the constructive criticism received through the week by the horns and go back to what they do best. The infamous silent protest is covered along with the game against Wellington, the upcoming game against Heart, the tickets given to underprivileged kids and much more. Check out www.westsydneyfootball.com for more.</itunes:summary>
+		<itunes:keywords>around the bloc, western sydney wanders, rbb, football, soccer, aleague, wsw rbb</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+			<media:content url="http://aroundthebloc.podbean.com/mf/web/dvxajq/LOGO.jpg" medium="image">
+					<media:title type="html">Episode 18: Seriously this time… Back to our Roots</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}i:49;O:20:"PicoFeed\Parser\Item":12:{s:3:"rtl";a:8:{i:0;s:2:"ar";i:1;s:2:"fa";i:2;s:2:"ur";i:3;s:2:"ps";i:4;s:3:"syr";i:5;s:2:"dv";i:6;s:2:"he";i:7;s:2:"yi";}s:2:"id";s:64:"04394c9ec5c3e540e4050ab9ec295165ab182541074e2c0eb33aafc6d6db6a8b";s:5:"title";s:34:"Episode 17: Live From the JERRcave";s:3:"url";s:69:"http://aroundthebloc.podbean.com/e/episode-17-live-from-the-jerrcave/";s:6:"author";s:13:"aroundthebloc";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2013-03-07 04:57:39.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"content";s:700:"<p>JAR, Speccy, Turner and Erebus rock up to Jerrad, Joey and Tahj’s pad for a game of UNO and a podcast ensues. The Wanderers winning against Mariners and going top of the league, the upcoming game against Wellington, an ‘in-the-making’ documentary about the Wanderers and the RBB and the recent charity work that has seen some underprivileged community groups receive tickets to the Nix game are all discussed. As it stands, JJ &amp; T are up 2-0 in the FIFA 13 stakes, comfortably defeating the team of JAR and two blokes who don’t know how to play FIFA in two games. Follow us on twitter @ABTWSF or www.facebook.com/aroundthebloc . Also check out www.westsydneyfootball.com for more.
+</p>";s:13:"enclosure_url";s:81:"http://aroundthebloc.podbean.com/mf/feed/tynye6/Around_the_bloc_podcast_ep017.mp3";s:14:"enclosure_type";s:10:"audio/mpeg";s:8:"language";s:2:"en";s:3:"xml";s:3559:"<item>
+		<title>Episode 17: Live From the JERRcave</title>
+		<link>http://aroundthebloc.podbean.com/e/episode-17-live-from-the-jerrcave/</link>
+		<comments>http://aroundthebloc.podbean.com/e/episode-17-live-from-the-jerrcave/#comments</comments>
+		<pubDate>Thu, 07 Mar 2013 04:57:39 +0000</pubDate>
+		<dc:creator>aroundthebloc</dc:creator>
+		
+	<category>Uncategorized</category>
+		<guid isPermaLink="false">http://aroundthebloc.podbean.com/2013/03/06/episode-17-live-from-the-jerrcave/</guid>
+		<description><![CDATA[<p>JAR, Speccy, Turner and Erebus rock up to Jerrad, Joey and Tahj’s pad for a game of UNO and a podcast ensues. The Wanderers winning against Mariners and going top of the league, the upcoming game against Wellington, an ‘in-the-making’ documentary about the Wanderers and the RBB and the recent charity work that has seen some underprivileged community groups receive tickets to the Nix game are all discussed. As it stands, JJ &#38; T are up 2-0 in the FIFA 13 stakes, comfortably defeating the team of JAR and two blokes who don’t know how to play FIFA in two games. Follow us on twitter @ABTWSF or www.facebook.com/aroundthebloc . Also check out www.westsydneyfootball.com for more.
+</p>
+]]></description>
+			<content:encoded><![CDATA[<p>JAR, Speccy, Turner and Erebus rock up to Jerrad, Joey and Tahj’s pad for a game of UNO and a podcast ensues. The Wanderers winning against Mariners and going top of the league, the upcoming game against Wellington, an ‘in-the-making’ documentary about the Wanderers and the RBB and the recent charity work that has seen some underprivileged community groups receive tickets to the Nix game are all discussed. As it stands, JJ &amp; T are up 2-0 in the FIFA 13 stakes, comfortably defeating the team of JAR and two blokes who don’t know how to play FIFA in two games. Follow us on twitter @ABTWSF or www.facebook.com/aroundthebloc . Also check out www.westsydneyfootball.com for more.
+</p>
+]]></content:encoded>
+			<wfw:commentRss>http://aroundthebloc.podbean.com/e/episode-17-live-from-the-jerrcave/feed/</wfw:commentRss>
+			<enclosure url="http://aroundthebloc.podbean.com/mf/feed/tynye6/Around_the_bloc_podcast_ep017.mp3" length="17787196" type="audio/mpeg"/>
+				<itunes:subtitle>JAR, Speccy, Turner and Erebus rock up to Jerrad, Joey and Tahj's pad for a game of UNO and a podcast ensues. The Wanderers winning ...</itunes:subtitle>
+		<itunes:summary>JAR, Speccy, Turner and Erebus rock up to Jerrad, Joey and Tahj's pad for a game of UNO and a podcast ensues. The Wanderers winning against Mariners and going top of the league, the upcoming game against Wellington, an 'in-the-making' documentary about the Wanderers and the RBB and the recent charity work that has seen some underprivileged community groups receive tickets to the Nix game are all discussed. As it stands, JJ  T are up 2-0 in the FIFA 13 stakes, comfortably defeating the team of JAR and two blokes who don't know how to play FIFA in two games. Follow us on twitter @ABTWSF or www.facebook.com/aroundthebloc . Also check out www.westsydneyfootball.com for more.</itunes:summary>
+		<itunes:keywords>rbb around the bloc westsydneyfootball aleague western sydney wanderers</itunes:keywords>
+		<itunes:author>Around the Bloc</itunes:author>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:block>No</itunes:block>
+			<media:content url="http://aroundthebloc.podbean.com/mf/web/dvxajq/LOGO.jpg" medium="image">
+					<media:title type="html">Episode 17: Live From the JERRcave</media:title></media:content>	</item>";s:10:"namespaces";a:6:{s:4:"atom";s:27:"http://www.w3.org/2005/Atom";s:6:"itunes";s:42:"http://www.itunes.com/dtds/podcast-1.0.dtd";s:2:"dc";s:32:"http://purl.org/dc/elements/1.1/";s:7:"content";s:40:"http://purl.org/rss/1.0/modules/content/";s:3:"wfw";s:36:"http://wellformedweb.org/CommentAPI/";s:5:"media";s:29:"http://search.yahoo.com/mrss/";}}}s:2:"id";s:33:"http://aroundthebloc.podbean.com/";s:5:"title";s:15:"Around the Bloc";s:11:"description";s:169:"The Official Supporters Podcast of the Western Sydney Wanderers. www.aroundthebloc.com.au Now on iTunes - https://itunes.apple.com/au/podcast/around-the-bloc/id581817326";s:8:"feed_url";s:0:"";s:8:"site_url";s:33:"http://aroundthebloc.podbean.com/";s:4:"date";O:8:"DateTime":3:{s:4:"date";s:26:"2014-12-16 12:56:02.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:8:"language";s:2:"en";s:4:"logo";s:72:"http://imglogo.podbean.com/image-logo/586645/ATBLogo-BlackBackground.png";s:4:"icon";s:0:"";}


### PR DESCRIPTION
Because the Item instances store a SimpleXMLElement in the xml
attribute, it was not possible to cache/serialize a Feed or Item
instance (Error: Serialization of 'SimpleXMLElement' is not allowed).

This is now fixed :-)