### PR TITLE
GrabberRulesFolder settings overrides the default folder

### DIFF
--- a/lib/PicoFeed/Scraper/RuleLoader.php
+++ b/lib/PicoFeed/Scraper/RuleLoader.php
@@ -111,11 +111,13 @@ class RuleLoader
      */
     public function getRulesFolders()
     {
-        $folders = array(__DIR__.'/../Rules');
+        $folders = array();
 
         if ($this->config !== null && $this->config->getGrabberRulesFolder() !== null) {
             $folders[] = $this->config->getGrabberRulesFolder();
         }
+
+        $folders[] = __DIR__ . '/../Rules';
 
         return $folders;
     }

--- a/tests/Scraper/RuleLoaderTest.php
+++ b/tests/Scraper/RuleLoaderTest.php
@@ -26,8 +26,8 @@ class RuleLoaderTest extends PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($dirs);
         $this->assertCount(2, $dirs);
-        $this->assertTrue(strpos($dirs[0], '/../Rules') !== false);
-        $this->assertEquals('/foobar/rules', $dirs[1]);
+        $this->assertTrue(strpos($dirs[1], '/../Rules') !== false);
+        $this->assertEquals('/foobar/rules', $dirs[0]);
 
         // No custom path with empty config object
         $loader = new RuleLoader(new Config());


### PR DESCRIPTION
Without this, there is no way to override the default filters.