### PR TITLE
Exceptions for Basic auth errors

### DIFF
--- a/docs/exceptions.markdown
+++ b/docs/exceptions.markdown
@@ -15,6 +15,8 @@ All exceptions inherits from the standard `Exception` class.
 - `PicoFeed\Client\MaxRedirectException`: Maximum of HTTP redirections reached
 - `PicoFeed\Client\MaxSizeException`: The response size exceeds to maximum allowed
 - `PicoFeed\Client\TimeoutException`: Connection timeout
+- `PicoFeed\Client\ForbiddenException`: Thrown for HTTP 403, meaning that the user does not have the rights to access the feed
+- `PicoFeed\Client\UnauthorizedException`: Thrown for HTTP 401, meaning that the user did not provide credentials or provided wrong credentials
 
 ### Parser Exceptions
 

--- a/docs/feed-parsing.markdown
+++ b/docs/feed-parsing.markdown
@@ -178,7 +178,7 @@ catch (PicoFeedException $e) {
 
 HTTP basic auth
 ---------------
-If a feed requires basic auth headers, you can pass them as parameters to the **download** method, e.g.:
+If a feed requires basic auth headers, you can pass them as parameters to the **download** or **discover** method, e.g.:
 
 ```php
 try {
@@ -189,6 +189,9 @@ try {
 
     // Provide those values to the download method
     $resource = $reader->download('http://linuxfr.org/news.atom', '', '', $user, $password);
+
+    // or
+    $resource = $reader->discover('http://linuxfr.org/news.atom', '', '', $user, $password);
 
     // Return true if the remote content has changed
     if ($resource->isModified()) {
@@ -214,6 +217,11 @@ catch (PicoFeedException $e) {
     // Do something...
 }
 ```
+
+To check if the authorization was successful you can test for the following thrown exceptions (see [exceptions](exceptions.markdown)):
+
+* **ForbiddenException**
+* **UnauthorizedException**
 
 Custom regex filters
 --------------------

--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -211,7 +211,7 @@ abstract class Client
 
         $this->status_code = $response['status'];
         $this->handleNotModifiedResponse($response);
-        $this->handleNotFoundResponse($response);
+        $this->handleErrorResponse($response);
         $this->handleNormalResponse($response);
 
         return $this;
@@ -222,7 +222,7 @@ abstract class Client
      *
      * @param array $response Client response
      */
-    public function handleNotModifiedResponse(array $response)
+    protected function handleNotModifiedResponse(array $response)
     {
         if ($response['status'] == 304) {
             $this->is_modified = false;
@@ -238,13 +238,18 @@ abstract class Client
     }
 
     /**
-     * Handle not found response.
+     * Handle Http Error codes
      *
      * @param array $response Client response
      */
-    public function handleNotFoundResponse(array $response)
+    protected function handleErrorResponse(array $response)
     {
-        if ($response['status'] == 404) {
+        $status = $response['status'];
+        if ($status == 401) {
+            throw new UnauthorizedException('Wrong or missing credentials');
+        } else if ($status == 403) {
+            throw new ForbiddenException('Not allowed to access resource');
+        } else if ($status == 404) {
             throw new InvalidUrlException('Resource not found');
         }
     }
@@ -254,7 +259,7 @@ abstract class Client
      *
      * @param array $response Client response
      */
-    public function handleNormalResponse(array $response)
+    protected function handleNormalResponse(array $response)
     {
         if ($response['status'] == 200) {
             $this->content = $response['body'];

--- a/lib/PicoFeed/Client/ForbiddenException.php
+++ b/lib/PicoFeed/Client/ForbiddenException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PicoFeed\Client;
+
+/**
+ * MaxRedirectException Exception.
+ *
+ * @author  Bernhard Posselt
+ */
+class ForbiddenException extends ClientException
+{
+}

--- a/lib/PicoFeed/Client/ForbiddenException.php
+++ b/lib/PicoFeed/Client/ForbiddenException.php
@@ -3,8 +3,6 @@
 namespace PicoFeed\Client;
 
 /**
- * MaxRedirectException Exception.
- *
  * @author  Bernhard Posselt
  */
 class ForbiddenException extends ClientException

--- a/lib/PicoFeed/Client/UnauthorizedException.php
+++ b/lib/PicoFeed/Client/UnauthorizedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PicoFeed\Client;
+
+/**
+ * MaxRedirectException Exception.
+ *
+ * @author  Bernhard Posselt
+ */
+class UnauthorizedException extends ClientException
+{
+}

--- a/lib/PicoFeed/Client/UnauthorizedException.php
+++ b/lib/PicoFeed/Client/UnauthorizedException.php
@@ -3,8 +3,6 @@
 namespace PicoFeed\Client;
 
 /**
- * MaxRedirectException Exception.
- *
  * @author  Bernhard Posselt
  */
 class UnauthorizedException extends ClientException


### PR DESCRIPTION
I was working on getting Basic Auth in for the News app but needed a way to tell the user that his credentials were correct. Manually checking for the statuscode proved to be clunky, so I've added the most common cases (401 and 403) as exceptions.

Furthermore the handle* methods look like pure internal stuff, so I made them protected (keeping in mind that other clients may want to override them).

Furthermore the more useful **discover** method was not documented for basic auth, so I've added that.

Unfortunately no tests, because it's a pain to write them without dependency injection (you'd need to spin up a custom server answering with those error codes).

@mkresin @fguillot 