### PR TITLE
Update testDownload to reflect changes to the miniflux.net homepage

### DIFF
--- a/tests/Client/CurlTest.php
+++ b/tests/Client/CurlTest.php
@@ -12,13 +12,13 @@ class CurlTest extends PHPUnit_Framework_TestCase
     public function testDownload()
     {
         $client = new Curl();
-        $client->setUrl('http://miniflux.net/index.html');
+        $client->setUrl('http://miniflux.net/');
         $result = $client->doRequest();
 
         $this->assertTrue(is_array($result));
         $this->assertEquals(200, $result['status']);
         $this->assertEquals('<!DOC', substr($result['body'], 0, 5));
-        $this->assertEquals('text/html; charset=utf-8', $result['headers']['Content-Type']);
+        $this->assertEquals('text/html; charset=UTF-8', $result['headers']['Content-Type']);
     }
 
     /**


### PR DESCRIPTION
The test was failing because of changes on miniflux.net.