### PR TITLE
Support requesting delta feeds (RFC3229+feed)

### DIFF
--- a/lib/PicoFeed/Client/Curl.php
+++ b/lib/PicoFeed/Client/Curl.php
@@ -136,6 +136,7 @@ class Curl extends Client
 
         if ($this->etag) {
             $headers[] = 'If-None-Match: '.$this->etag;
+            $headers[] = 'A-IM: feed';
         }
 
         if ($this->last_modified) {

--- a/lib/PicoFeed/Client/Stream.php
+++ b/lib/PicoFeed/Client/Stream.php
@@ -31,6 +31,7 @@ class Stream extends Client
 
         if ($this->etag) {
             $headers[] = 'If-None-Match: '.$this->etag;
+            $headers[] = 'A-IM: feed';
         }
 
         if ($this->last_modified) {


### PR DESCRIPTION
When sending a If-None-Match: $etag header, tag along a A-IM: feed
header. Supporting servers should only return content that has been added
or changed since they sent the etag. content. Should have no affect on
servers who doesn’t support this. Saves bandwidth when supported.

Supported by ExpressionEngine, Textpattern, and Liferea. I’m working on adding support to more feed readers and hope to add it to WordPress soon.
