### PR TITLE
Add fallbacks for publishedDate and updatedDate

### DIFF
--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -222,18 +222,20 @@ abstract class Parser implements ParserInterface
     public function findItemDate(SimpleXMLElement $entry, Item $item, Feed $feed)
     {
         $this->findItemPublishedDate($entry, $item, $feed);
-        $published = $item->getPublishedDate();
-
         $this->findItemUpdatedDate($entry, $item, $feed);
-        $updated = $item->getUpdatedDate();
 
-        if ($published === null && $updated === null) {
-            $item->setDate($feed->getDate()); // We use the feed date if there is no date for the item
-        } elseif ($published !== null && $updated !== null) {
-            $item->setDate(max($published, $updated)); // We use the most recent date between published and updated
-        } else {
-            $item->setDate($updated ?: $published);
+        if ($item->getPublishedDate() === null) {
+            // Use the updated date if available, otherwise use the feed date
+            $item->setPublishedDate($item->getUpdatedDate() ?: $feed->getDate());
         }
+
+        if ($item->getUpdatedDate() === null) {
+            // Use the published date as fallback
+            $item->setUpdatedDate($item->getPublishedDate());
+        }
+
+        // Use the most recent of published and updated dates
+        $item->setDate(max($item->getPublishedDate(), $item->getUpdatedDate()));
     }
 
     /**

--- a/tests/Parser/AtomParserTest.php
+++ b/tests/Parser/AtomParserTest.php
@@ -319,6 +319,15 @@ class AtomParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1433451720, $feed->items[1]->getDate()->getTimestamp());
         $this->assertEquals(1433451900, $feed->items[2]->getDate()->getTimestamp());
 
+        $this->assertEquals(1433451720, $feed->items[0]->getUpdatedDate()->getTimestamp());
+        $this->assertEquals(1433451720, $feed->items[0]->getPublishedDate()->getTimestamp());
+
+        $this->assertEquals(1433451720, $feed->items[1]->getUpdatedDate()->getTimestamp());
+        $this->assertEquals(1433451720, $feed->items[1]->getPublishedDate()->getTimestamp());
+
+        $this->assertEquals(1433451900, $feed->items[2]->getUpdatedDate()->getTimestamp());
+        $this->assertEquals(1433451900, $feed->items[2]->getPublishedDate()->getTimestamp());
+
         $parser = new Atom(file_get_contents('tests/fixtures/atom_no_default_namespace.xml'));
         $feed = $parser->execute();
         $this->assertEquals(1433451720, $feed->items[0]->getDate()->getTimestamp());

--- a/tests/Parser/Rss10ParserTest.php
+++ b/tests/Parser/Rss10ParserTest.php
@@ -306,6 +306,12 @@ class Rss10ParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1433451720, $feed->items[0]->getDate()->getTimestamp()); // item date
         $this->assertEquals(1433451900, $feed->items[1]->getDate()->getTimestamp()); // fallback to feed date
 
+        $this->assertEquals(1433451720, $feed->items[0]->getUpdatedDate()->getTimestamp()); // item date
+        $this->assertEquals(1433451720, $feed->items[0]->getPublishedDate()->getTimestamp()); // item date
+
+        $this->assertEquals(1433451900, $feed->items[1]->getUpdatedDate()->getTimestamp()); // fallback to feed date
+        $this->assertEquals(1433451900, $feed->items[1]->getPublishedDate()->getTimestamp()); // fallback to feed date
+
         $parser = new Rss10(file_get_contents('tests/fixtures/rss_10_empty_item.xml'));
         $feed = $parser->execute();
         $this->assertEquals(time(), $feed->items[0]->getDate()->getTimestamp(), 1);

--- a/tests/Parser/Rss20ParserTest.php
+++ b/tests/Parser/Rss20ParserTest.php
@@ -224,6 +224,12 @@ class Rss20ParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1433451720, $feed->items[0]->getDate()->getTimestamp()); // item date
         $this->assertEquals(1433451900, $feed->items[1]->getDate()->getTimestamp()); // fallback to feed date
 
+        $this->assertEquals(1433451720, $feed->items[0]->getUpdatedDate()->getTimestamp()); // item date
+        $this->assertEquals(1433451720, $feed->items[0]->getPublishedDate()->getTimestamp()); // item date
+
+        $this->assertEquals(1433451900, $feed->items[1]->getUpdatedDate()->getTimestamp()); // fallback to feed date
+        $this->assertEquals(1433451900, $feed->items[1]->getPublishedDate()->getTimestamp()); // fallback to feed date
+
         $parser = new Rss20(file_get_contents('tests/fixtures/rss_20_empty_item.xml'));
         $feed = $parser->execute();
         $this->assertEquals(time(), $feed->items[0]->getDate()->getTimestamp(), 1);


### PR DESCRIPTION
Use `publishedDate` and `updatedDate` as fallbacks for each other, or use the feed date if neither is available. (e.g. if `publishedDate` is not available, set it to `updatedDate` and vice versa)

This also adds some tests for the `publishedDate` and `updatedDate` properties.

cc: @BernhardPosselt re https://github.com/nextcloud/news/pull/43
> Right, you can add the checks at both places but if there's a sensible default it should be done once in the library rather than forcing all users to deal with nulls :D