### PR TITLE
[FIX] setConfig for PostProcessor/Base

### DIFF
--- a/lib/PicoFeed/Base.php
+++ b/lib/PicoFeed/Base.php
@@ -31,4 +31,8 @@ abstract class Base
         $this->config = $config ?: new Config();
         Logger::setTimezone($this->config->getTimezone());
     }
+
+    public function setConfig(Config $config) {
+        $this->config = $config;
+    }
 }

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -329,6 +329,7 @@ abstract class Parser implements ParserInterface
     public function setConfig($config)
     {
         $this->config = $config;
+        $this->itemPostProcessor->setConfig($config);
         return $this;
     }
 

--- a/lib/PicoFeed/Processor/ItemPostProcessor.php
+++ b/lib/PicoFeed/Processor/ItemPostProcessor.php
@@ -5,6 +5,7 @@ namespace PicoFeed\Processor;
 use PicoFeed\Base;
 use PicoFeed\Parser\Feed;
 use PicoFeed\Parser\Item;
+use PicoFeed\Config\Config;
 
 /**
  * Item Post Processor
@@ -92,5 +93,14 @@ class ItemPostProcessor extends Base
     public function getProcessor($class)
     {
         return isset($this->processors[$class]) ? $this->processors[$class] : null;
+    }
+
+    public function setConfig(Config $config)
+    {
+        foreach ($this->processors as $processor) {
+            $processor->setConfig($config);
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Hi Frédéric,

I noticed that the Config was not respected in the ContentFilterProcessor.

This happened because in the constructor of Parser, $this->config is not yet set. So the fix I did properly propagates the Config via Parser->setConfig, ItemPostProcessor->setConfig, ContentFilterProcessor.

I'm open to do improvements for this code based on your feedback.

Best Regards,
Nils