### PR TITLE
fix using dateParser property in Parser

### DIFF
--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -258,7 +258,7 @@ abstract class Parser implements ParserInterface
     public function getDateParser()
     {
         if ($this->dateParser === null) {
-            return new DateParser($this->config);
+            $this->dateParser = new DateParser($this->config);
         }
 
         return $this->dateParser;


### PR DESCRIPTION
Now property dateParser is not used, because every time method getDateParser returns new DateParser()